### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: qntx/workflows/.github/workflows/release.yml@main


### PR DESCRIPTION
## Description

Add `.github/workflows/release.yml` to automate release builds and publishing.

Closes #37.

## Changes

- Add `release.yml` workflow, triggered on `v*` tags push and manual dispatch, using the reusable `qntx/workflows/.github/workflows/release.yml@main` workflow.