### PR TITLE
feat: EVM upto and batch-settlement (official TS parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 The facilitator is a trusted third party that acts on behalf of resource servers. It does not hold funds — it only validates payment payloads and broadcasts settlement transactions to the blockchain.
 
-Built on [r402](https://github.com/qntx/r402) **0.17.1**. This 1.0.0 process ships **EIP-155 exact** and **Solana exact**; extra EVM schemes land in later PRs. See [Security](SECURITY.md) before using in production.
+Built on [r402](https://github.com/qntx/r402) **0.17.1**. Default features host EIP-155 **exact** and **upto**, plus **Solana exact**. `batch-settlement` is opt-in. This process does **not** host `auth-capture`. See [Security](SECURITY.md) before using in production.
 
 ## Quick Start
 
@@ -46,7 +46,7 @@ docker run -p 8080:8080 -v ./config.toml:/app/config.toml ghcr.io/qntx/facilitat
 
 # Or build from source
 docker build -t facilitator .
-docker build -t facilitator --build-arg FEATURES=chain-eip155,telemetry .
+docker build -t facilitator --build-arg FEATURES=chain-eip155,scheme-upto,telemetry .
 docker run -p 8080:8080 -v ./config.toml:/app/config.toml facilitator
 ```
 
@@ -115,7 +115,7 @@ receipt_timeout_secs = 20
 rpc = "https://api.devnet.solana.com"
 ```
 
-Do **not** add `[[schemes]]`. Schemes are compile-time (`chain-eip155` registers EVM exact, `chain-solana` registers Solana exact). A `schemes` key is a startup error.
+Do **not** add `[[schemes]]`. Schemes are compile-time (`chain-eip155` registers EVM exact; `scheme-upto` / `scheme-batch-settlement` register those schemes; `chain-solana` registers Solana exact). A `schemes` key is a startup error. This process does not host `auth-capture`.
 
 Empty `[chains]`, an unknown CAIP-2 namespace, or a family not compiled into the binary is a startup error.
 
@@ -135,6 +135,9 @@ HTTP timeouts: 30 s on `/verify`, `/settle`, and `/supported`; 5 s on `/health`.
 | Family | This build | Notes |
 | --- | --- | --- |
 | **EVM (EIP-155) exact** | default | Ethereum, Base, and any `eip155:<id>` with RPC + signer |
+| **EVM (EIP-155) upto** | default (`scheme-upto`) | Permit2 usage-based; official TS `UptoEvmScheme` |
+| **EVM (EIP-155) batch-settlement** | opt-in | r402 `MemoryChannelStore` is **single-process**. Pin settle to one replica; do not split the store across workers. |
+| **EVM (EIP-155) auth-capture** | not hosted | Official TS facilitator servers do not register it |
 | **Solana (SVM) exact** | default | Any `solana:<genesis>` with RPC + base58 keypair |
 
 ## Feature Flags
@@ -143,10 +146,12 @@ HTTP timeouts: 30 s on `/verify`, `/settle`, and `/supported`; 5 s on `/health`.
 | --- | --- | --- |
 | `chain-eip155` | ✓ | EVM exact via [r402-evm](https://crates.io/crates/r402-evm) 0.17.1 |
 | `chain-solana` | ✓ | Solana exact via [r402-solana](https://crates.io/crates/r402-solana) 0.17.1 |
+| `scheme-upto` | ✓ | Register EVM `upto`. Requires `chain-eip155`. Registration-only (does not compile r402-evm modules out). |
+| `scheme-batch-settlement` | | Register EVM `batch-settlement`. Requires `chain-eip155`. `MemoryChannelStore` is in-memory per process. |
 | `telemetry` | ✓ | OpenTelemetry tracing and metrics |
 
 ```bash
-cargo install facilitator --no-default-features --features chain-eip155,chain-solana
+cargo install facilitator --no-default-features --features chain-eip155,chain-solana,scheme-upto
 ```
 
 ## Security

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,7 +4,8 @@
 # Key concepts:
 #   - [signers]  — configure private keys ONCE, shared across all chains
 #   - [chains.*] — only RPC endpoints needed per chain
-#   - Schemes are compiled in (EVM exact + Solana exact this build). Do not add [[schemes]].
+#   - Schemes are Cargo features (EVM exact, Solana exact, scheme-upto; opt-in scheme-batch-settlement).
+#     Do not add [[schemes]]. This process does not host auth-capture.
 #   - Env var references: "$VAR" or "${VAR}" are resolved at startup
 
 host = "0.0.0.0"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -17,9 +17,12 @@ name = "facilitator"
 path = "src/main.rs"
 
 [features]
-default = ["telemetry", "chain-eip155", "chain-solana"]
+default = ["telemetry", "chain-eip155", "chain-solana", "scheme-upto"]
 chain-eip155 = ["dep:r402-evm", "dep:alloy-network", "dep:alloy-signer-local", "dep:url"]
 chain-solana = ["dep:r402-solana", "dep:solana-keypair", "dep:bs58"]
+# Registration-only: r402-evm always compiles upto / batch_settlement with `facilitator`.
+scheme-upto = ["chain-eip155"]
+scheme-batch-settlement = ["chain-eip155"]
 telemetry = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",

--- a/facilitator/src/chain/eip155.rs
+++ b/facilitator/src/chain/eip155.rs
@@ -6,9 +6,9 @@ use alloy_network::EthereumWallet;
 use alloy_signer_local::PrivateKeySigner;
 use r402_core::chain::{ChainId, ChainProvider};
 use r402_core::facilitator::DynFacilitator;
-use r402_core::scheme::SchemeBuilder;
-use r402_evm::Eip155Exact;
+use r402_core::scheme::{SchemeBuilder, SchemeId, SchemeRegistry};
 use r402_evm::chain::{Eip155ChainProvider, Eip155ChainReference};
+use r402_evm::{Eip155BatchSettlement, Eip155Exact, Eip155Upto};
 use serde::Deserialize;
 use url::Url;
 
@@ -36,6 +36,74 @@ impl SchemeBuilder<&Eip155Handle> for Eip155Exact {
     ) -> Result<Box<dyn DynFacilitator>, Box<dyn std::error::Error + Send + Sync>> {
         SchemeBuilder::<Arc<Eip155ChainProvider>>::build(self, Arc::clone(&provider.0), config)
     }
+}
+
+impl SchemeBuilder<&Eip155Handle> for Eip155Upto {
+    fn build(
+        &self,
+        provider: &Eip155Handle,
+        config: Option<serde_json::Value>,
+    ) -> Result<Box<dyn DynFacilitator>, Box<dyn std::error::Error + Send + Sync>> {
+        SchemeBuilder::<Arc<Eip155ChainProvider>>::build(self, Arc::clone(&provider.0), config)
+    }
+}
+
+impl SchemeBuilder<&Eip155Handle> for Eip155BatchSettlement {
+    fn build(
+        &self,
+        provider: &Eip155Handle,
+        config: Option<serde_json::Value>,
+    ) -> Result<Box<dyn DynFacilitator>, Box<dyn std::error::Error + Send + Sync>> {
+        SchemeBuilder::<Arc<Eip155ChainProvider>>::build(self, Arc::clone(&provider.0), config)
+    }
+}
+
+/// Scheme names `register_eip155_schemes` registers for each EIP-155 chain.
+///
+/// Extra schemes are registration-only Cargo features; auth-capture is never listed.
+#[cfg(test)]
+#[must_use]
+fn eip155_registered_scheme_names() -> Vec<&'static str> {
+    let mut names = vec![Eip155Exact.scheme()];
+    #[cfg(feature = "scheme-upto")]
+    names.push(Eip155Upto.scheme());
+    #[cfg(feature = "scheme-batch-settlement")]
+    names.push(Eip155BatchSettlement.scheme());
+    names
+}
+
+/// Register compiled EVM schemes for one chain handle.
+///
+/// # Errors
+///
+/// Returns an error if a scheme blueprint fails to build.
+pub(crate) fn register_eip155_schemes(
+    registry: &mut SchemeRegistry,
+    handle: &Eip155Handle,
+) -> Result<(), AppError> {
+    registry.register(&Eip155Exact, handle, None).map_err(|e| {
+        AppError::chain(format!(
+            "failed to register eip155 {}: {e}",
+            Eip155Exact.scheme()
+        ))
+    })?;
+    #[cfg(feature = "scheme-upto")]
+    registry.register(&Eip155Upto, handle, None).map_err(|e| {
+        AppError::chain(format!(
+            "failed to register eip155 {}: {e}",
+            Eip155Upto.scheme()
+        ))
+    })?;
+    #[cfg(feature = "scheme-batch-settlement")]
+    registry
+        .register(&Eip155BatchSettlement, handle, None)
+        .map_err(|e| {
+            AppError::chain(format!(
+                "failed to register eip155 {}: {e}",
+                Eip155BatchSettlement.scheme()
+            ))
+        })?;
+    Ok(())
 }
 
 /// Single RPC endpoint entry for EVM chains.
@@ -173,4 +241,111 @@ pub(crate) fn build_eip155_handle(config: &Eip155ChainConfig) -> Result<Eip155Ha
     .map_err(|e| AppError::chain(format!("EVM provider init failed: {e}")))?;
 
     Ok(Eip155Handle(Arc::new(provider)))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::routes::{self, FacilitatorState};
+
+    /// Anvil account #0 — never used on-chain; `supported` is local.
+    const TEST_SIGNER: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    fn test_handle() -> Eip155Handle {
+        let config = Eip155ChainConfig {
+            chain_reference: Eip155ChainReference::new(84532),
+            inner: Eip155ChainConfigInner {
+                rpc: vec![Eip155RpcEndpoint {
+                    http: "http://127.0.0.1:9".to_owned(),
+                    rate_limit: None,
+                }],
+                signers: vec![TEST_SIGNER.to_owned()],
+                eip1559: true,
+                flashblocks: false,
+                receipt_timeout_secs: 20,
+            },
+        };
+        build_eip155_handle(&config).expect("test Eip155Handle")
+    }
+
+    #[test]
+    fn registered_scheme_names_match_official_ts_hosting() {
+        let names = eip155_registered_scheme_names();
+        assert!(names.contains(&"exact"), "exact is always registered");
+        assert!(
+            !names.contains(&"auth-capture"),
+            "auth-capture is not hosted"
+        );
+        #[cfg(feature = "scheme-upto")]
+        assert!(names.contains(&"upto"), "scheme-upto registers upto");
+        #[cfg(not(feature = "scheme-upto"))]
+        assert!(!names.contains(&"upto"), "scheme-upto off");
+        #[cfg(feature = "scheme-batch-settlement")]
+        assert!(
+            names.contains(&"batch-settlement"),
+            "scheme-batch-settlement registers batch-settlement"
+        );
+        #[cfg(not(feature = "scheme-batch-settlement"))]
+        assert!(
+            !names.contains(&"batch-settlement"),
+            "scheme-batch-settlement off"
+        );
+    }
+
+    #[tokio::test]
+    async fn http_supported_matches_registered_schemes() {
+        let handle = test_handle();
+        let mut registry = SchemeRegistry::new();
+        register_eip155_schemes(&mut registry, &handle).expect("register");
+        let state: FacilitatorState = Arc::new(registry);
+        let app = routes::routes().with_state(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/supported")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("oneshot");
+        assert_eq!(response.status(), StatusCode::OK, "GET /supported is 200");
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body")
+            .to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let kinds = json
+            .get("kinds")
+            .and_then(serde_json::Value::as_array)
+            .expect("kinds");
+        let mut got: Vec<&str> = kinds
+            .iter()
+            .map(|kind| {
+                kind.get("scheme")
+                    .and_then(serde_json::Value::as_str)
+                    .expect("scheme")
+            })
+            .collect();
+        got.sort_unstable();
+        let mut expected = eip155_registered_scheme_names();
+        expected.sort_unstable();
+        assert_eq!(got, expected, "GET /supported schemes");
+        assert!(!got.contains(&"auth-capture"), "auth-capture is not hosted");
+        assert!(
+            kinds
+                .iter()
+                .all(|kind| kind.get("x402Version").and_then(serde_json::Value::as_u64) == Some(2)),
+            "kinds are v2"
+        );
+        #[cfg(feature = "scheme-upto")]
+        assert!(got.contains(&"upto"), "/supported includes upto");
+    }
 }

--- a/facilitator/src/commands/init.rs
+++ b/facilitator/src/commands/init.rs
@@ -83,7 +83,8 @@ log_level = "info"
 #
 # Key format: "eip155:<chain_id>"
 # Only RPC config is needed; signers are injected from [signers] above.
-# Schemes are compiled in (exact); do not add [[schemes]].
+# Schemes are Cargo features (exact; scheme-upto; scheme-batch-settlement).
+# Do not add [[schemes]]. This process does not host auth-capture.
 
 [chains."eip155:84532"]
 rpc = [{ http = "https://sepolia.base.org" }]

--- a/facilitator/src/commands/serve.rs
+++ b/facilitator/src/commands/serve.rs
@@ -78,15 +78,11 @@ async fn build_registry(config: &crate::config::Config) -> Result<SchemeRegistry
 
     #[cfg(feature = "chain-eip155")]
     {
-        use r402_evm::Eip155Exact;
-
-        use crate::chain::eip155::build_eip155_handle;
+        use crate::chain::eip155::{build_eip155_handle, register_eip155_schemes};
 
         for chain in config.chains().eip155() {
             let handle = build_eip155_handle(chain)?;
-            registry
-                .register(&Eip155Exact, &handle, None)
-                .map_err(|e| AppError::chain(format!("failed to register eip155 exact: {e}")))?;
+            register_eip155_schemes(&mut registry, &handle)?;
         }
     }
 

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -2,11 +2,11 @@
 //!
 //! Composes r402 in-process scheme facilitators and serves spec §7 routes.
 
-// Dev-dependencies are linked into the lib test target; they are consumed
-// by `tests/http_wire.rs`, not by unit tests in this crate.
-#[cfg(test)]
+// Dev-dependencies are linked into the lib test target. With `chain-eip155`
+// they are used by GET /supported unit tests; without it, silence unused_crate_dependencies.
+#[cfg(all(test, not(feature = "chain-eip155")))]
 use http_body_util as _;
-#[cfg(test)]
+#[cfg(all(test, not(feature = "chain-eip155")))]
 use tower as _;
 
 mod chain;


### PR DESCRIPTION
Register EVM upto (default) and batch-settlement (opt-in). Completes 1.0.0 default features with the Solana PR below this.

Does not host auth-capture.