### PR TITLE
chore: deploy stack for 1.0.0 (no 0.6.0 config)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #
 # Build:
 #   docker build -t x402-facilitator .
-#   docker build -t x402-facilitator --build-arg FEATURES=chain-eip155,telemetry .
+#   docker build -t x402-facilitator --build-arg FEATURES=chain-eip155,chain-solana,scheme-upto,telemetry .
 #
 # Run:
 #   docker run -p 8080:8080 -v ./config.toml:/app/config.toml x402-facilitator
@@ -34,7 +34,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ------------------ Stage 3: Build dependencies + binary --------------------
 FROM chef AS builder
 
-ARG FEATURES=telemetry,chain-eip155
+ARG FEATURES=chain-eip155,chain-solana,scheme-upto,telemetry
 
 COPY --from=planner /src/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,17 +34,18 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ------------------ Stage 3: Build dependencies + binary --------------------
 FROM chef AS builder
 
+# --no-default-features: FEATURES is the image set, not an overlay on crate defaults.
 ARG FEATURES=chain-eip155,chain-solana,scheme-upto,telemetry
 
 COPY --from=planner /src/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo chef cook --release --features "${FEATURES}" --recipe-path recipe.json
+    cargo chef cook --release --no-default-features --features "${FEATURES}" --recipe-path recipe.json
 
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo build --release --features "${FEATURES}" --bin facilitator \
+    cargo build --release --no-default-features --features "${FEATURES}" --bin facilitator \
     && cp target/release/facilitator /usr/local/bin/facilitator \
     && strip /usr/local/bin/facilitator
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ Requires **Rust 1.95**.
 # Using pre-built image
 docker run -p 8080:8080 -v ./config.toml:/app/config.toml ghcr.io/qntx/facilitator
 
-# Or build from source
+# Or build from source (1.0.0 default FEATURES)
 docker build -t facilitator .
-docker build -t facilitator --build-arg FEATURES=chain-eip155,scheme-upto,telemetry .
+docker build -t facilitator --build-arg FEATURES=chain-eip155,chain-solana,scheme-upto,telemetry .
 docker run -p 8080:8080 -v ./config.toml:/app/config.toml facilitator
 ```
+
+Production stack (Caddy + Watchtower): [`deploy/`](deploy/). Watchtower rolling restart is **off** — see cache note below.
 
 ## API
 
@@ -139,6 +141,8 @@ HTTP timeouts: 30 s on `/verify`, `/settle`, and `/supported`; 5 s on `/health`.
 | **EVM (EIP-155) batch-settlement** | opt-in | r402 `MemoryChannelStore` is **single-process**. Pin settle to one replica; do not split the store across workers. |
 | **EVM (EIP-155) auth-capture** | not hosted | Official TS facilitator servers do not register it |
 | **Solana (SVM) exact** | default | Any `solana:<genesis>` with RPC + base58 keypair |
+
+`SettlementCache` (in-memory, TTL 120 s) and `MemoryChannelStore` live in one process. Two overlapping containers behind Caddy split both (duplicate `/settle`). `deploy/docker-compose.yml` sets `WATCHTOWER_ROLLING_RESTART=false` so image bumps stop-then-start (brief blip). Do not turn rolling restart on.
 
 ## Feature Flags
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker build -t facilitator --build-arg FEATURES=chain-eip155,chain-solana,schem
 docker run -p 8080:8080 -v ./config.toml:/app/config.toml facilitator
 ```
 
-Production stack (Caddy + Watchtower): [`deploy/`](deploy/). Watchtower rolling restart is **off** — see cache note below.
+Production stack (Caddy + Watchtower): [`deploy/`](deploy/). One replica; do not scale — see cache note below.
 
 ## API
 
@@ -142,7 +142,7 @@ HTTP timeouts: 30 s on `/verify`, `/settle`, and `/supported`; 5 s on `/health`.
 | **EVM (EIP-155) auth-capture** | not hosted | Official TS facilitator servers do not register it |
 | **Solana (SVM) exact** | default | Any `solana:<genesis>` with RPC + base58 keypair |
 
-`SettlementCache` (in-memory, TTL 120 s) and `MemoryChannelStore` live in one process. Two overlapping containers behind Caddy split both (duplicate `/settle`). `deploy/docker-compose.yml` sets `WATCHTOWER_ROLLING_RESTART=false` so image bumps stop-then-start (brief blip). Do not turn rolling restart on.
+`SettlementCache` (in-memory, TTL 120 s) is per process. `MemoryChannelStore` exists only if `scheme-batch-settlement` is built. Pin `/settle` to one replica; do not scale or put two facilitators behind one Caddy. Watchtower rolling restart does not overlap two copies of this compose service.
 
 ## Feature Flags
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -67,6 +67,11 @@ facilitator.qntx.fun {
 	# ── Reverse Proxy ────────────────────────────────────────────────
 	# Docker Compose: use container name "facilitator"
 	# Standalone:     change to "localhost:8080"
+	#
+	# No transport timeout on reverse_proxy. Caddy is unlimited; Axum 30 s
+	# is the process cap on /verify /settle /supported. Do not add a Caddy
+	# timeout unless it is strictly above 30 s + margin.
+	# Protocol surface is those three routes plus process /health. No GET /.
 
 	handle /health {
 		reverse_proxy facilitator:8080

--- a/deploy/Justfile
+++ b/deploy/Justfile
@@ -22,7 +22,7 @@ deploy:
 reload:
     if command -v fctl >/dev/null 2>&1; then fctl reload; else bash fctl reload; fi
 
-# Pull latest Docker images and perform a rolling restart.
+# Pull latest Docker images and recreate the facilitator (stop-then-start).
 update:
     if command -v fctl >/dev/null 2>&1; then fctl update; else bash fctl update; fi
 

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -23,7 +23,7 @@ reload: ## Smart reload (auto-detect which config changed)
 	@$(CTL) reload
 
 .PHONY: update
-update: ## Pull latest Docker images + rolling restart
+update: ## Pull latest Docker images + recreate (stop-then-start)
 	@$(CTL) update
 
 .PHONY: up

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,8 @@
-# x402 Facilitator — Deploy
+# x402 Facilitator — Deploy (1.0.0)
 
-x402 payment facilitator for on-chain verification and settlement. Handles EVM and Solana chains with automatic HTTPS, rate limiting, and zero-downtime updates.
+x402 V2 payment facilitator for on-chain verification and settlement. Default image hosts EIP-155 **exact** + **upto** and Solana **exact** (`chain-eip155,chain-solana,scheme-upto,telemetry`). Automatic HTTPS and rate limiting via Caddy.
+
+This is **not** facilitator 0.6.0. There is no `[[schemes]]` table, no `r402-svm`, and no `GET /`. Swap the image **and** replace `config.toml` with the 1.0.0 schema. 0.6.0 config will not load.
 
 ## Architecture
 
@@ -16,9 +18,15 @@ flowchart LR
     B <-- HTTP --> C
 ```
 
-- **Caddy** — Auto-HTTPS, rate limiting, security headers, request filtering
-- **Facilitator** — x402 payment verification, settlement, signer key management
-- **Watchtower** — Auto-pulls new images every 5 min, rolling restarts
+- **Caddy** — Auto-HTTPS, rate limiting, security headers, request filtering. `reverse_proxy facilitator:8080` has **no** transport timeout; Axum **30 s** is the process cap on `/verify`, `/settle`, and `/supported`.
+- **Facilitator** — x402 V2 `POST /verify`, `POST /settle`, `GET /supported`, plus process `GET /health`. Signer keys stay in `config.toml` / env.
+- **Watchtower** — Auto-pulls new images every 5 min. Rolling restart is **off** (`WATCHTOWER_ROLLING_RESTART=false`). Image bumps stop the old container then start the new one (brief blip).
+
+## In-memory cache (single worker)
+
+r402 `SettlementCache` (TTL 120 s) and, if you build `scheme-batch-settlement`, `MemoryChannelStore` are **per process**. Two overlapping containers behind Caddy split both: a `/settle` that reserved in A can be replayed on B.
+
+Do **not** enable Watchtower rolling restart. Pin `/settle` to one replica. Do not run two facilitator workers sharing one Caddy vhost.
 
 ## Prerequisites
 
@@ -34,16 +42,18 @@ cd facilitator-deploy
 
 # 1. Configure — edit these two files:
 cp config.example.toml config.toml
-nano config.toml    # Add EVM / Solana signer private keys
+nano config.toml    # Add EVM / Solana signer private keys (or $VAR + env)
 nano Caddyfile      # Set your domain (replace facilitator.qntx.fun)
 
 # 2. Deploy — one command does everything:
 sudo bash setup.sh
 
-# 3. Verify:
+# 3. Verify (protocol + process; there is no GET /):
 curl https://YOUR_DOMAIN/health
 curl https://YOUR_DOMAIN/supported
 ```
+
+`GET /supported` kinds must be `x402Version: 2` only. A leftover `[[schemes]]` key is a startup error — delete it.
 
 The setup script is **idempotent** — safe to re-run after failures. It resumes from where it stopped.
 
@@ -62,7 +72,7 @@ After setup, use `fctl` (installed to PATH) or `make` shortcuts:
 | --- | --- | --- |
 | `fctl deploy` | `make deploy` | Pull latest images + recreate containers + health check |
 | `fctl reload` | `make reload` | Smart reload — auto-detects which config changed |
-| `fctl update` | `make update` | Pull latest Docker images + rolling restart |
+| `fctl update` | `make update` | Pull latest Docker images + recreate (stop-then-start) |
 
 ### Observability
 
@@ -104,10 +114,10 @@ fctl reload                # Auto-detects config.toml changed → restarts only 
 ### Update Docker images manually
 
 ```bash
-fctl update                # Pulls latest facilitator → rolling restart → health check
+fctl update                # Pulls latest facilitator → recreate (stop-then-start) → health check
 ```
 
-> Watchtower also auto-updates every 5 minutes. Manual update is only needed for immediate updates.
+> Watchtower also auto-updates every 5 minutes (stop-then-start, not rolling). Manual update is only needed for immediate updates.
 
 ### Something broken → diagnose
 
@@ -125,24 +135,38 @@ fctl restore 20260213-160000
 fctl deploy                # Apply restored config
 ```
 
+A 1.0.0 V2 client cannot roll back to a 0.6.0 / r402 0.15.0 image. Restore previous **product**, not a compatible downgrade.
+
 ## Configuration Reference
 
 ### `config.toml` — Signer Keys & Chains
 
-```toml
-[signers]
-evm = ["0xYOUR_EVM_PRIVATE_KEY_HERE"]       # hex, 0x-prefixed
-solana = "YOUR_SOLANA_KEYPAIR_BASE58_HERE"   # base58, 64-byte keypair
+1.0.0 schema. No `[[schemes]]`. Schemes come from the image Cargo features.
 
-[chains."eip155:8453"]
-rpc = [{ http = "https://base-mainnet.g.alchemy.com/v2/$KEY" }]
+```toml
+host = "0.0.0.0"
+port = 8080
+log_level = "info"
+
+[signers]
+evm = ["$EVM_SIGNER_PRIVATE_KEY"]       # hex, 0x-prefixed
+solana = "$SOLANA_SIGNER_PRIVATE_KEY"    # base58, 64-byte keypair
+
+[chains."eip155:84532"]
+rpc = [{ http = "https://sepolia.base.org" }]
+receipt_timeout_secs = 20
+
+[chains."solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"]
+rpc = "https://api.devnet.solana.com"
 ```
+
+`receipt_timeout_secs` defaults to **20** and must stay below the **30 s** HTTP / client timeout. Operators who need longer waits raise client `timeoutMs`, process HTTP timeout, and `receipt_timeout_secs` together.
 
 > **RPC tip:** Do NOT use free public RPCs in production. Use [Alchemy](https://alchemy.com), [QuickNode](https://quicknode.com), [dRPC](https://drpc.org), or [Helius](https://helius.dev) (Solana).
 
 ### `Caddyfile` — Domain & TLS
 
-Replace `facilitator.qntx.fun` with your domain. Everything else is pre-configured (auto-TLS, rate limiting, security headers).
+Replace `facilitator.qntx.fun` with your domain. Everything else is pre-configured (auto-TLS, rate limiting, security headers). Do not add a `reverse_proxy` transport timeout unless it is strictly above 30 s + margin.
 
 ## Security Notes
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,14 +19,14 @@ flowchart LR
 ```
 
 - **Caddy** — Auto-HTTPS, rate limiting, security headers, request filtering. `reverse_proxy facilitator:8080` has **no** transport timeout; Axum **30 s** is the process cap on `/verify`, `/settle`, and `/supported`.
-- **Facilitator** — x402 V2 `POST /verify`, `POST /settle`, `GET /supported`, plus process `GET /health`. Signer keys stay in `config.toml` / env.
-- **Watchtower** — Auto-pulls new images every 5 min. Rolling restart is **off** (`WATCHTOWER_ROLLING_RESTART=false`). Image bumps stop the old container then start the new one (brief blip).
+- **Facilitator** — x402 V2 `POST /verify`, `POST /settle`, `GET /supported`, plus process `GET /health`. Signer keys stay in `config.toml` or in container env (`EVM_SIGNER_PRIVATE_KEY` / `SOLANA_SIGNER_PRIVATE_KEY`). `stop_grace_period: 35s` so SIGTERM can finish the 30 s HTTP budget.
+- **Watchtower** — Auto-pulls new images every 5 min. `WATCHTOWER_ROLLING_RESTART=false`, `WATCHTOWER_TIMEOUT=35`. Rolling restart does **not** overlap two facilitators; with one labeled container it is the same stop-then-start. Do **not** scale.
 
 ## In-memory cache (single worker)
 
-r402 `SettlementCache` (TTL 120 s) and, if you build `scheme-batch-settlement`, `MemoryChannelStore` are **per process**. Two overlapping containers behind Caddy split both: a `/settle` that reserved in A can be replayed on B.
+r402 `SettlementCache` (TTL 120 s) is per process. `MemoryChannelStore` exists only if you build `scheme-batch-settlement`. Two facilitator processes behind one Caddy split those stores: a `/settle` reserved in A can replay on B.
 
-Do **not** enable Watchtower rolling restart. Pin `/settle` to one replica. Do not run two facilitator workers sharing one Caddy vhost.
+Run **one** replica. Do not `docker compose up --scale facilitator=2` (this file's `container_name` already forbids a second copy of the service). A second stack or a second binary sharing the vhost is the failure mode. Watchtower rolling restart does **not** overlap two facilitators.
 
 ## Prerequisites
 
@@ -42,7 +42,7 @@ cd facilitator-deploy
 
 # 1. Configure — edit these two files:
 cp config.example.toml config.toml
-nano config.toml    # Add EVM / Solana signer private keys (or $VAR + env)
+nano config.toml    # literals, or keep $VAR and put keys in .env / host env
 nano Caddyfile      # Set your domain (replace facilitator.qntx.fun)
 
 # 2. Deploy — one command does everything:
@@ -117,7 +117,7 @@ fctl reload                # Auto-detects config.toml changed → restarts only 
 fctl update                # Pulls latest facilitator → recreate (stop-then-start) → health check
 ```
 
-> Watchtower also auto-updates every 5 minutes (stop-then-start, not rolling). Manual update is only needed for immediate updates.
+> Watchtower also auto-updates every 5 minutes (stop-then-start of the one replica). Manual update is only needed for immediate updates.
 
 ### Something broken → diagnose
 
@@ -161,6 +161,8 @@ rpc = "https://api.devnet.solana.com"
 ```
 
 `receipt_timeout_secs` defaults to **20** and must stay below the **30 s** HTTP / client timeout. Operators who need longer waits raise client `timeoutMs`, process HTTP timeout, and `receipt_timeout_secs` together.
+
+`$EVM_SIGNER_PRIVATE_KEY` / `$SOLANA_SIGNER_PRIVATE_KEY` are resolved inside the container. Compose interpolates host env or a compose-directory `.env` and passes both through `environment:`. Host `export` without that block does not reach the process. Literals in `config.toml` skip env.
 
 > **RPC tip:** Do NOT use free public RPCs in production. Use [Alchemy](https://alchemy.com), [QuickNode](https://quicknode.com), [dRPC](https://drpc.org), or [Helius](https://helius.dev) (Solana).
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -20,7 +20,7 @@ flowchart LR
 
 - **Caddy** — Auto-HTTPS, rate limiting, security headers, request filtering. `reverse_proxy facilitator:8080` has **no** transport timeout; Axum **30 s** is the process cap on `/verify`, `/settle`, and `/supported`.
 - **Facilitator** — x402 V2 `POST /verify`, `POST /settle`, `GET /supported`, plus process `GET /health`. Signer keys stay in `config.toml` or in container env (`EVM_SIGNER_PRIVATE_KEY` / `SOLANA_SIGNER_PRIVATE_KEY`). `stop_grace_period: 35s` so SIGTERM can finish the 30 s HTTP budget.
-- **Watchtower** — Auto-pulls new images every 5 min. `WATCHTOWER_ROLLING_RESTART=false`, `WATCHTOWER_TIMEOUT=35`. Rolling restart does **not** overlap two facilitators; with one labeled container it is the same stop-then-start. Do **not** scale.
+- **Watchtower** — Auto-pulls new images every 5 min. `WATCHTOWER_ROLLING_RESTART=false`, `WATCHTOWER_TIMEOUT=35s` (Go duration; unit required). Rolling restart does **not** overlap two facilitators; with one labeled container it is the same stop-then-start. Do **not** scale.
 
 ## In-memory cache (single worker)
 

--- a/deploy/config.example.toml
+++ b/deploy/config.example.toml
@@ -1,15 +1,21 @@
-# x402 Facilitator Configuration
-# https://qntx.fun
+# x402 Facilitator Configuration (1.0.0)
+# https://qntx.org
 #
 # SETUP:
 #   cp config.example.toml config.toml
 #   chmod 600 config.toml
-#   nano config.toml   # Fill in your signer private keys
+#   nano config.toml   # Fill in signer keys, or keep $VAR and export them
 #
 # Key concepts:
-#   - [signers]  — configure private keys ONCE, shared across all chains
-#   - [chains.*] — only RPC endpoints needed per chain
-#   - Schemes are compiled in (EVM exact + Solana exact this build). Do not add [[schemes]].
+#   - [signers]  — private keys ONCE, shared across all chains of that family
+#   - [chains.*] — RPC (and optional per-chain overrides) per CAIP-2 id
+#   - Schemes are Cargo features on the 1.0.0 image:
+#       chain-eip155 + scheme-upto  → EVM exact + upto
+#       chain-solana                → Solana exact
+#     Opt-in at build: scheme-batch-settlement. This process does not host auth-capture.
+#     Do not add [[schemes]] — that key is a startup error.
+#   - Env var references: "$VAR" or "${VAR}" are resolved at startup.
+#     Literals (0x… / base58) also work.
 
 host = "0.0.0.0"
 port = 8080
@@ -24,13 +30,15 @@ log_level = "info"
 # directly in the chain table.
 
 [signers]
-evm = ["0xYOUR_EVM_PRIVATE_KEY_HERE"]          # hex, 0x-prefixed
-solana = "YOUR_SOLANA_KEYPAIR_BASE58_HERE"     # base58, 64-byte keypair
+evm = ["$EVM_SIGNER_PRIVATE_KEY"]          # hex, 0x-prefixed
+solana = "$SOLANA_SIGNER_PRIVATE_KEY"      # base58, 64-byte keypair
 
 # EIP-155 (EVM) Chains — Mainnet
 #
 # Key format: "eip155:<chain_id>"
-# Only RPC config needed — signers injected from [signers] above.
+# rpc is an array of { http, rate_limit? }. Signers inject from [signers] unless
+# the chain table sets `signers`.
+# receipt_timeout_secs defaults to 20 (must stay below the 30 s HTTP timeout).
 
 # Ethereum (chain 1)
 [chains."eip155:1"]
@@ -133,6 +141,7 @@ rpc = [{ http = "https://ethereum-sepolia-rpc.publicnode.com" }]
 # Base Sepolia (chain 84532)
 [chains."eip155:84532"]
 rpc = [{ http = "https://sepolia.base.org" }]
+receipt_timeout_secs = 20
 
 # Optimism Sepolia (chain 11155420)
 [chains."eip155:11155420"]
@@ -205,6 +214,10 @@ rpc = [{ http = "https://rpc.apothem.network" }]
 # Solana Chains
 #
 # Key format: "solana:<truncated_genesis_hash>"
+# rpc is a string (not an EVM endpoint array). Optional: pubsub,
+# max_compute_unit_limit (200000), max_compute_unit_price (1000000),
+# enable_smart_wallet_verification (false), allow_additional_instructions (true),
+# max_instruction_count (6).
 
 # Solana Mainnet
 [chains."solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"]

--- a/deploy/config.example.toml
+++ b/deploy/config.example.toml
@@ -4,7 +4,7 @@
 # SETUP:
 #   cp config.example.toml config.toml
 #   chmod 600 config.toml
-#   nano config.toml   # Fill in signer keys, or keep $VAR and export them
+#   nano config.toml   # literals, or keep $VAR (compose injects the env vars below)
 #
 # Key concepts:
 #   - [signers]  — private keys ONCE, shared across all chains of that family

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     deploy:
       resources:
         limits:
+          # Starting cap. SVM + many EVM chains may need more — measure, don't guess.
           memory: 512M
           cpus: "0.90"
     logging:
@@ -49,8 +50,9 @@ services:
       WATCHTOWER_POLL_INTERVAL: 300
       # Remove old images after update
       WATCHTOWER_CLEANUP: "true"
-      # Rolling restart — wait for new container to be healthy before removing old
-      WATCHTOWER_ROLLING_RESTART: "true"
+      # Stop-then-start. Rolling restart overlaps old+new containers behind Caddy
+      # and splits in-memory SettlementCache / MemoryChannelStore (duplicate settle).
+      WATCHTOWER_ROLLING_RESTART: "false"
     logging:
       driver: json-file
       options:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -57,8 +57,8 @@ services:
       WATCHTOWER_POLL_INTERVAL: 300
       # Remove old images after update
       WATCHTOWER_CLEANUP: "true"
-      # Match facilitator stop_grace_period so SIGTERM can finish the 30 s HTTP budget.
-      WATCHTOWER_TIMEOUT: "35"
+      # Go duration. Unitless "35" is 35ns then Docker Stop timeout 0 → SIGKILL.
+      WATCHTOWER_TIMEOUT: "35s"
       # One replica (container_name). Rolling restart does not overlap two facilitators;
       # cache split is scale / a second worker behind Caddy, not this flag.
       WATCHTOWER_ROLLING_RESTART: "false"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -17,6 +17,13 @@ services:
       - "127.0.0.1:8080:8080"   # Only bind to loopback — Caddy handles public traffic
     volumes:
       - ./config.toml:/app/config.toml:ro
+    # $VAR in config.toml is resolved from process env. Host export / compose-dir
+    # .env interpolates here; without this block those keys never enter the container.
+    environment:
+      EVM_SIGNER_PRIVATE_KEY: ${EVM_SIGNER_PRIVATE_KEY}
+      SOLANA_SIGNER_PRIVATE_KEY: ${SOLANA_SIGNER_PRIVATE_KEY}
+    # Axum protocol timeout is 30 s. Default 10 s SIGKILL can cut /settle after broadcast.
+    stop_grace_period: 35s
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
       interval: 15s
@@ -50,8 +57,10 @@ services:
       WATCHTOWER_POLL_INTERVAL: 300
       # Remove old images after update
       WATCHTOWER_CLEANUP: "true"
-      # Stop-then-start. Rolling restart overlaps old+new containers behind Caddy
-      # and splits in-memory SettlementCache / MemoryChannelStore (duplicate settle).
+      # Match facilitator stop_grace_period so SIGTERM can finish the 30 s HTTP budget.
+      WATCHTOWER_TIMEOUT: "35"
+      # One replica (container_name). Rolling restart does not overlap two facilitators;
+      # cache split is scale / a second worker behind Caddy, not this flag.
       WATCHTOWER_ROLLING_RESTART: "false"
     logging:
       driver: json-file

--- a/deploy/fctl
+++ b/deploy/fctl
@@ -206,7 +206,7 @@ cmd_update() {
     info "Pulling latest facilitator image..."
     ${DC} pull facilitator
 
-    info "Rolling restart with latest image..."
+    info "Recreating facilitator with latest image (stop-then-start)..."
     ${DC} up -d --no-deps --force-recreate facilitator
 
     wait_healthy
@@ -524,7 +524,7 @@ cmd_help() {
     echo "  ${BOLD}Lifecycle:${NC}"
     echo "    deploy          Pull latest images + recreate all containers"
     echo "    reload          Smart reload (auto-detect config changes)"
-    echo "    update          Pull latest facilitator image + rolling restart"
+    echo "    update          Pull latest facilitator image + recreate (stop-then-start)"
     echo ""
     echo "  ${BOLD}Observability:${NC}"
     echo "    status          Service dashboard (status, health, versions)"


### PR DESCRIPTION
Dockerfile FEATURES chain-eip155,chain-solana,scheme-upto,telemetry. Watchtower one replica, timeout 35s. Signer env injected into compose. No Caddy reverse_proxy timeout.