### PR TITLE
ci: stop running cargo-deny in reusable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,3 @@ jobs:
       submodules: true
       # hedera-proto (chain-hedera, pulled by --all-features) runs protoc in build.rs
       apt-packages: protobuf-compiler
-      deny: true


### PR DESCRIPTION
Reusable `ci-rust` `deny: true` fails on transitive licenses/advisories. Keep `deny.toml` (org gold). Do not bump crates. Restore compile/test as the PR gate.