### PR TITLE
feat: compose aptos, keeta, tvm, stellar, concordium exact facilitators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
           test -f "$dest/crates/r402-protocol/Cargo.toml"
           test -f "$dest/crates/r402-near/Cargo.toml"
           test -f "$dest/crates/r402-avm/Cargo.toml"
+          test -f "$dest/crates/r402-aptos/Cargo.toml"
+          test -f "$dest/crates/r402-concordium/Cargo.toml"
 
       # hedera-proto (r402-hedera) runs prost-build. ubuntu-latest ships
       # neither protoc nor google/protobuf/*.proto (wrappers.proto).
@@ -114,7 +116,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy families
-        run: cargo clippy --workspace --all-targets --features near,xrpl,hedera,avm -- -D warnings
+        run: cargo clippy --workspace --all-targets --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium -- -D warnings
 
       - name: Test families
-        run: cargo test --workspace --verbose --features near,xrpl,hedera,avm
+        run: cargo test --workspace --verbose --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aes-gcm-siv"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5fdcfed8f106be3df944054aaa42bc13ae103a3ac8a9f4b08d4f053e3a743f8"
 dependencies = [
  "alloy-primitives",
- "num_enum",
+ "num_enum 0.7.6",
  "phf",
 ]
 
@@ -137,7 +151,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -201,7 +215,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -273,7 +287,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "serde",
  "serde_with",
@@ -326,7 +340,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -356,7 +370,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 2.1.1",
  "fixed-cache",
  "foldhash 0.2.0",
  "hashbrown 0.17.1",
@@ -592,7 +606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b37db6a7ad8170596345f864522f789cc7af093f516d6cdf34bbdcfba8adab"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -616,7 +630,7 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64 0.22.1",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
  "governor 0.10.4",
@@ -658,7 +672,7 @@ checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.1.1",
  "nybbles",
  "serde",
  "smallvec",
@@ -787,6 +801,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-bcs"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef2367d495719360c63badd2c85a1c001f8b3eaafca068bd505fc757ba7e1c8"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aptos-sdk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e47ecba6a2dd27800904ffb3dbfda6d417ba6f6bf409e4ea5ad0b7d525257f"
+dependencies = [
+ "anyhow",
+ "aptos-bcs",
+ "aws-lc-sys",
+ "const-hex",
+ "ed25519-dalek 2.2.0",
+ "futures",
+ "k256",
+ "p256",
+ "rand 0.8.8",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3 0.10.9",
+ "thiserror 2.0.20",
+ "tokio",
+ "url",
+ "urlencoding",
+ "zeroize",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +854,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-poly",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -971,6 +1052,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1080,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
+ "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint 0.4.8",
@@ -1009,11 +1104,22 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.6.0",
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint 0.4.8",
  "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1094,7 +1200,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -1123,6 +1229,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
@@ -1168,6 +1280,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1343,6 +1461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39-dict"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da82dc4f71ce6f0e3b56fdc3d0fcb5d7f2e97f77e20af0512b0ebdb6b9308ea"
+dependencies = [
+ "cryptoxide",
+]
+
+[[package]]
 name = "bitcoin-consensus-encoding"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1599,16 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "bitvec-nom2"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d988fcc40055ceaa85edc55875a08f8abd29018582647fd82ad6128dba14a5f0"
+dependencies = [
+ "bitvec",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1525,7 +1677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cdfe656708a01f89b451a7d36466e6fe6c414de0aa18fc54f864f6f9ca9f56"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 3.0.4",
@@ -1735,9 +1887,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1748,6 +1918,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1861,6 +2032,176 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
+name = "concordium-contracts-common"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bacf3a0689d3ac154085e322eb98b0db16caa61436421d991d54ba25aaf0da3"
+dependencies = [
+ "base64 0.21.7",
+ "bs58 0.5.1",
+ "chrono",
+ "concordium-contracts-common-derive",
+ "fnv",
+ "hashbrown 0.11.2",
+ "hex",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-traits",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "concordium-contracts-common-derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3482ffacf3c18133be976c1b874b6e87e018ac0316e9385888b43df07fa39c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "concordium-rust-sdk"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28358a70e30a360e1072f7eb6d63263ad705e3627aeac5c709c5d706d9a0f4d8"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "assert_matches",
+ "chrono",
+ "concordium-smart-contract-engine",
+ "concordium_base",
+ "derive_more 0.99.20",
+ "ed25519-dalek 2.2.0",
+ "futures",
+ "hex",
+ "http 1.5.0",
+ "num 0.4.3",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "prost 0.13.5",
+ "rand 0.8.8",
+ "rust_decimal",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "concordium-smart-contract-engine"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286534f820438f29a0448c3f5e368a092b84241dbf08ac99fe38ccdb0534da15"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "concordium-contracts-common",
+ "concordium-wasm",
+ "derive_more 0.99.20",
+ "ed25519-zebra",
+ "futures",
+ "libc",
+ "num_enum 0.6.1",
+ "rand 0.8.8",
+ "secp256k1 0.22.2",
+ "serde",
+ "sha2 0.10.9",
+ "sha3 0.10.9",
+ "slab",
+ "thiserror 1.0.69",
+ "tinyvec",
+]
+
+[[package]]
+name = "concordium-wasm"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b5e16881ad746a68d1fbd96446d8ca5db399b9a9bcf71504f543af67557261"
+dependencies = [
+ "anyhow",
+ "concordium-contracts-common",
+ "derive_more 0.99.20",
+ "leb128",
+ "num_enum 0.6.1",
+]
+
+[[package]]
+name = "concordium_base"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3339e2b778eb8c4e61a94627ab2f8a091006a82c9297d38697487c8e5c3ed3"
+dependencies = [
+ "aes",
+ "anyhow",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "base64 0.22.1",
+ "bs58 0.5.1",
+ "byteorder",
+ "cbc",
+ "chrono",
+ "ciborium-io",
+ "ciborium-ll",
+ "concordium-contracts-common",
+ "concordium_base_derive",
+ "curve25519-dalek 4.1.3",
+ "derive_more 0.99.20",
+ "ed25519-dalek 2.2.0",
+ "either",
+ "ff",
+ "generic-array",
+ "hex",
+ "hmac",
+ "itertools 0.14.0",
+ "leb128",
+ "libc",
+ "nom 7.1.3",
+ "num 0.4.3",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "pbkdf2 0.11.0",
+ "rand 0.8.8",
+ "rayon",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "sha3 0.10.9",
+ "subtle",
+ "thiserror 2.0.20",
+ "zeroize",
+]
+
+[[package]]
+name = "concordium_base_derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506ed3d99b3ee6c674cc0c1e8ce95fa49fafd08b96754a6a83fc6cc34f9c373c"
+dependencies = [
+ "convert_case 0.8.0",
+ "darling 0.20.11",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +2250,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1962,6 +2318,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crate-git-revision"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -2047,6 +2425,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
+dependencies = [
+ "der",
+ "num-traits",
+ "serdect 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2456,12 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "cryptoxide"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb2a43afb0fd8b53101f79f153795c449ba80762361d8b868f4a75c6d03057"
 
 [[package]]
 name = "ctr"
@@ -2086,6 +2483,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto 0.2.9",
+ "group",
  "rand_core 0.6.4",
  "rustc_version 0.4.1",
  "serde",
@@ -2260,7 +2658,11 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
+ "bytes",
  "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2272,10 +2674,21 @@ checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2359,6 +2772,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -2372,7 +2798,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -2473,7 +2899,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "serdect",
+ "serdect 0.2.0",
  "signature 2.2.0",
  "spki",
 ]
@@ -2485,6 +2911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
+ "serde",
  "signature 2.2.0",
 ]
 
@@ -2526,6 +2953,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-zebra"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "hashbrown 0.16.1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,15 +2997,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
+ "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -2583,7 +3029,7 @@ dependencies = [
  "embedded-io-async",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -2673,6 +3119,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape-bytes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
+
+[[package]]
+name = "ethnum"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,20 +3158,26 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
  "axum 0.8.9",
+ "base64 0.23.1",
  "clap",
  "compact_str",
  "http-body-util",
  "humantime-serde",
  "metrics",
  "metrics-exporter-prometheus",
+ "r402-aptos",
  "r402-avm",
+ "r402-concordium",
  "r402-evm",
  "r402-extensions",
  "r402-facilitator",
  "r402-hedera",
+ "r402-keeta",
  "r402-near",
  "r402-protocol",
+ "r402-stellar",
  "r402-svm",
+ "r402-tvm",
  "r402-xrpl",
  "serde",
  "serde_json",
@@ -2739,6 +3203,15 @@ dependencies = [
  "libm",
  "rand 0.9.5",
  "siphasher",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -2781,6 +3254,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2865,13 +3339,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -2985,6 +3465,21 @@ name = "futures-io"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3101,10 +3596,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "governor"
@@ -3177,6 +3694,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3187,9 +3715,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3241,6 +3784,17 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+ "zeroize",
 ]
 
 [[package]]
@@ -3364,6 +3918,15 @@ name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -3505,6 +4068,7 @@ dependencies = [
  "http 1.5.0",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -3999,6 +4563,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.5.0",
+ "http-body",
+ "http-body-util",
+ "jsonrpsee-types",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
+dependencies = [
+ "base64 0.22.1",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustls",
+ "rustls-platform-verifier 0.5.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tower 0.5.3",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
+dependencies = [
+ "http 1.5.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,8 +4629,9 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "serdect",
+ "serdect 0.2.0",
  "sha2 0.10.9",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -4042,6 +4664,208 @@ dependencies = [
 ]
 
 [[package]]
+name = "keetanetwork-account"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6974f20dbe30e39144b538eda541cac38b6a6f5047d34b5734b45260da66e0b"
+dependencies = [
+ "base32",
+ "bip39-dict",
+ "hex",
+ "keetanetwork-asn1",
+ "keetanetwork-crypto",
+ "keetanetwork-error",
+ "keetanetwork-utils",
+ "rand_core 0.9.5",
+ "snafu",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "zeroize",
+]
+
+[[package]]
+name = "keetanetwork-asn1"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "996be22376579b09dfb63d1fb83d9af76c259c10407687c965a26ec555cd8f56"
+dependencies = [
+ "chrono",
+ "const-oid",
+ "der",
+ "hex",
+ "keetanetwork-utils",
+ "lazy_static",
+ "num-bigint 0.4.8",
+ "rasn",
+ "rasn-compiler",
+ "serde",
+ "serde_json",
+ "snafu",
+ "spki",
+]
+
+[[package]]
+name = "keetanetwork-block"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb4b2729703f0c369a8e81c29078e4feea3b3e3e0423a3512a2e9e86bf7911e"
+dependencies = [
+ "chrono",
+ "hex",
+ "keetanetwork-account",
+ "keetanetwork-asn1",
+ "keetanetwork-crypto",
+ "keetanetwork-error",
+ "keetanetwork-utils",
+ "keetanetwork-x509",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "snafu",
+]
+
+[[package]]
+name = "keetanetwork-client"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fec3674e8721635018576842e1f65066a16bcc6b3601f62f3c6e682a48f54c6"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "gloo-timers",
+ "hex",
+ "js-sys",
+ "keetanetwork-account",
+ "keetanetwork-block",
+ "keetanetwork-crypto",
+ "keetanetwork-error",
+ "keetanetwork-vote",
+ "num-bigint 0.4.8",
+ "percent-encoding",
+ "prettyplease",
+ "progenitor",
+ "progenitor-client",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "snafu",
+ "spin",
+ "syn 2.0.119",
+ "tokio",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wstd",
+]
+
+[[package]]
+name = "keetanetwork-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e30aa34a75a4710209186eb875bdb0903e427d559ec631a62db01b1d56a581"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "base32",
+ "base64 0.22.1",
+ "bip39-dict",
+ "cbc",
+ "chrono",
+ "crypto-bigint 0.6.1",
+ "ctr",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek 2.2.0",
+ "hex",
+ "hkdf",
+ "hmac",
+ "k256",
+ "keetanetwork-asn1",
+ "keetanetwork-error",
+ "keetanetwork-utils",
+ "p256",
+ "pbkdf2 0.12.2",
+ "rand 0.9.5",
+ "rand_core 0.9.5",
+ "secrecy",
+ "sha2 0.10.9",
+ "sha3 0.10.9",
+ "signature 2.2.0",
+ "snafu",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "keetanetwork-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d724eb80fde180e1cd87cdbd72b3455bf7fd75da4eac53f4365b586a9918746"
+dependencies = [
+ "snafu",
+]
+
+[[package]]
+name = "keetanetwork-utils"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ea8c67441a70e53f28dd203326b6834b2663dd352a3f5aa9b09344efabd216"
+dependencies = [
+ "rasn-compiler",
+ "snafu",
+]
+
+[[package]]
+name = "keetanetwork-vote"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759eede474565a7e37bed201fbec610a1f37252544be7935e198abb659b6e4df"
+dependencies = [
+ "chrono",
+ "hex",
+ "keetanetwork-account",
+ "keetanetwork-asn1",
+ "keetanetwork-block",
+ "keetanetwork-crypto",
+ "keetanetwork-error",
+ "keetanetwork-utils",
+ "miniz_oxide 0.8.9",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "snafu",
+]
+
+[[package]]
+name = "keetanetwork-x509"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89754f6004141ec35da335ac0d86ba9ee9c453eb82c470b95129133d545b2c5a"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "der",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hex",
+ "keetanetwork-account",
+ "keetanetwork-asn1",
+ "keetanetwork-crypto",
+ "keetanetwork-error",
+ "keetanetwork-utils",
+ "rasn",
+ "serde",
+ "serde_json",
+ "snafu",
+ "x509-cert",
+]
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,6 +4885,15 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "libc"
@@ -4251,6 +5084,15 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
@@ -4294,6 +5136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nacl"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30aefc44d813c51b5e7952950e87c17f2e0e1a3274d63c8281a701e05323d548"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,7 +5177,7 @@ dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
- "derive_more",
+ "derive_more 2.1.1",
  "near-config-utils",
  "near-crypto",
  "near-parameters",
@@ -4368,7 +5216,7 @@ dependencies = [
  "borsh",
  "bs58 0.4.0",
  "curve25519-dalek 4.1.3",
- "derive_more",
+ "derive_more 2.1.1",
  "ed25519-dalek 2.2.0",
  "hex",
  "near-account-id",
@@ -4474,7 +5322,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "derive_builder",
- "derive_more",
+ "derive_more 2.1.1",
  "easy-ext",
  "enum-map",
  "hex",
@@ -4487,7 +5335,7 @@ dependencies = [
  "near-stdx",
  "near-time",
  "num-rational 0.3.2",
- "ordered-float",
+ "ordered-float 4.6.0",
  "primitive-types 0.10.1",
  "rand 0.8.8",
  "rand_chacha 0.3.1",
@@ -4513,7 +5361,7 @@ dependencies = [
  "base64 0.21.7",
  "borsh",
  "bs58 0.4.0",
- "derive_more",
+ "derive_more 2.1.1",
  "enum-map",
  "near-account-id",
  "near-gas",
@@ -4596,6 +5444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4603,6 +5460,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4640,6 +5506,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
+ "num-bigint 0.4.8",
  "num-complex 0.4.6",
  "num-integer",
  "num-iter",
@@ -4677,6 +5544,7 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4765,6 +5633,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -4791,12 +5660,33 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.7.6",
  "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4805,7 +5695,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4851,6 +5741,17 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openapiv3"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
+dependencies = [
+ "indexmap 2.14.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "openssl"
@@ -4923,6 +5824,15 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -4931,6 +5841,18 @@ dependencies = [
  "num-traits",
  "rand 0.8.8",
  "serde",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4955,7 +5877,7 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4991,6 +5913,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,6 +5953,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
+ "hmac",
+ "password-hash 0.4.2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5019,6 +5966,9 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac",
+ "password-hash 0.5.0",
+ "rayon",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5038,6 +5988,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -5220,6 +6179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5242,11 +6210,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -5278,6 +6256,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "progenitor"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba1d77160e6d5c95bdf0792527f76bf528791093fa83015bc2908a0ba9d076"
+dependencies = [
+ "progenitor-client",
+ "progenitor-impl",
+ "progenitor-macro",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8a874cf25a33cac7a01b9c1de87bcfbc8aea93f3156d09dcc3bee516a78926"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e349eed84b9a1a6a5dbe478d335e3df73d32a93c5eefe571c9b8cb298aab5d"
+dependencies = [
+ "heck 0.5.0",
+ "http 1.5.0",
+ "indexmap 2.14.1",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+ "thiserror 2.0.20",
+ "typify",
+ "unicode-ident",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa969a1349979c5f64347f204e794781a86d738206d75672e6c9493f5910002"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl",
+ "quote",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "serde_yaml",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5482,6 +6526,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r402-aptos"
+version = "0.19.1"
+dependencies = [
+ "aptos-sdk",
+ "base64 0.23.1",
+ "compact_str",
+ "r402-facilitator",
+ "r402-protocol",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
 name = "r402-avm"
 version = "0.19.1"
 dependencies = [
@@ -5508,6 +6568,26 @@ dependencies = [
  "compact_str",
  "http 1.5.0",
  "r402-protocol",
+]
+
+[[package]]
+name = "r402-concordium"
+version = "0.19.1"
+dependencies = [
+ "bs58 0.5.1",
+ "compact_str",
+ "concordium-rust-sdk",
+ "ed25519-dalek 2.2.0",
+ "hex",
+ "r402-facilitator",
+ "r402-protocol",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -5584,6 +6664,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "r402-keeta"
+version = "0.19.1"
+dependencies = [
+ "base64 0.23.1",
+ "compact_str",
+ "keetanetwork-account",
+ "keetanetwork-block",
+ "keetanetwork-client",
+ "keetanetwork-crypto",
+ "r402-facilitator",
+ "r402-protocol",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
 name = "r402-near"
 version = "0.19.1"
 dependencies = [
@@ -5619,6 +6719,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "r402-stellar"
+version = "0.19.1"
+dependencies = [
+ "compact_str",
+ "ed25519-dalek 3.0.0",
+ "r402-facilitator",
+ "r402-protocol",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "stellar-rpc-client",
+ "stellar-strkey 0.0.18",
+ "stellar-xdr",
+ "thiserror 2.0.20",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
 name = "r402-svm"
 version = "0.19.1"
 dependencies = [
@@ -5649,6 +6769,30 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "r402-tvm"
+version = "0.19.1"
+dependencies = [
+ "base64 0.23.1",
+ "compact_str",
+ "ed25519-dalek 3.0.0",
+ "hex",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "r402-facilitator",
+ "r402-protocol",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tonlib-core",
+ "tracing",
+ "tracing-core",
+ "url",
 ]
 
 [[package]]
@@ -5804,6 +6948,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "rasn"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c133e7d35d847c312f98e0769e0a96e66677c59196b3a135ae86ffce353cd6c9"
+dependencies = [
+ "bitvec",
+ "bitvec-nom2",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "nom 7.1.3",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "rasn-derive",
+ "serde_json",
+ "snafu",
+ "xml-no-std",
+]
+
+[[package]]
+name = "rasn-compiler"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99b8e029b3b38ed1ea50e78e8fa484a5c86e913f29cc7ff09e0de109bd291e1"
+dependencies = [
+ "chrono",
+ "nom 8.0.0",
+ "num 0.4.3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rasn-derive"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871a10a1ba4c3dfb1091746970e84cbd182a9578d0b6b8a9b89ee080a45476b2"
+dependencies = [
+ "proc-macro2",
+ "rasn-derive-impl",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "rasn-derive-impl"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb7c9cab0fd1dd92ec7d3a1b9ebbd0f9f2ce19a88152cd5993dce2709a00f8e"
+dependencies = [
+ "either",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "uuid",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5891,6 +7098,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "regress"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5943,6 +7160,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.5.0",
  "http-body",
@@ -5961,15 +7179,18 @@ dependencies = [
  "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -6091,6 +7312,7 @@ dependencies = [
  "serde",
  "serde_json",
  "wasm-bindgen",
+ "zmij",
 ]
 
 [[package]]
@@ -6135,7 +7357,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -6158,6 +7380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6190,6 +7413,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
@@ -6205,7 +7449,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 1.0.9",
  "windows-sys 0.61.2",
 ]
 
@@ -6226,7 +7470,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 1.0.9",
  "windows-sys 0.61.2",
 ]
 
@@ -6289,6 +7533,20 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -6309,6 +7567,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6338,9 +7608,18 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "295642060261c80709ac034f52fca8e5a9fa2c7d341ded5cdb164b7c33768b2a"
+dependencies = [
+ "secp256k1-sys 0.5.2",
 ]
 
 [[package]]
@@ -6378,6 +7657,15 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
@@ -6401,6 +7689,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -6440,6 +7738,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "semver-parser"
@@ -6461,11 +7763,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-aux"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207f67b28fe90fb596503a9bf0bf1ea5e831e21307658e177c5dfcdfc3ab8a0a"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
 name = "serde-big-array"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -6500,11 +7824,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap 2.14.1",
  "itoa",
  "memchr",
  "serde",
@@ -6544,6 +7880,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_tokenstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6568,6 +7916,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.1",
  "jiff",
+ "schemars 0.8.22",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -6612,6 +7961,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6631,6 +7990,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -6642,6 +8002,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -6776,6 +8145,27 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8392,6 +9782,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8467,7 +9863,7 @@ dependencies = [
  "bytemuck_derive",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey 3.0.0",
@@ -8486,7 +9882,7 @@ dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-account-info",
  "solana-cpi",
  "solana-instruction",
@@ -8514,7 +9910,7 @@ dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
@@ -8543,7 +9939,7 @@ dependencies = [
  "getrandom 0.2.17",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-account-info",
  "solana-address 2.7.0",
  "solana-instruction",
@@ -8622,7 +10018,7 @@ dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-address 2.7.0",
  "solana-instruction",
  "solana-nullable",
@@ -8642,7 +10038,7 @@ dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-instruction",
  "solana-program-error",
  "solana-program-option",
@@ -8680,7 +10076,7 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-address 2.7.0",
  "solana-borsh",
  "solana-instruction",
@@ -8700,7 +10096,7 @@ dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
- "num_enum",
+ "num_enum 0.7.6",
  "solana-account-info",
  "solana-program-error",
  "solana-zero-copy",
@@ -8719,6 +10115,82 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stellar-rpc-client"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b65ae2e8788c09fba690afa3b589094fd67ff4d7d5ec4502ec4f2d7d870576"
+dependencies = [
+ "clap",
+ "hex",
+ "http 1.5.0",
+ "itertools 0.10.5",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "stellar-strkey 0.0.16",
+ "stellar-xdr",
+ "termcolor",
+ "termcolor_output",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+dependencies = [
+ "crate-git-revision 0.0.6",
+ "data-encoding",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+dependencies = [
+ "crate-git-revision 0.0.6",
+ "data-encoding",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
+dependencies = [
+ "crate-git-revision 0.0.9",
+ "data-encoding",
+ "heapless 0.9.3",
+ "zeroize",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+dependencies = [
+ "base64 0.22.1",
+ "cfg_eval",
+ "crate-git-revision 0.0.6",
+ "escape-bytes",
+ "ethnum",
+ "hex",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "stellar-strkey 0.0.13",
+]
 
 [[package]]
 name = "strsim"
@@ -8740,6 +10212,15 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum_macros"
@@ -8764,6 +10245,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -8889,12 +10382,37 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand",
+ "fastrand 2.5.0",
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "termcolor_output"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0363afbf20990ea53a69c03b71800480aaf90e8f49f6fd5385ecc302062895ff"
+dependencies = [
+ "termcolor",
+ "termcolor_output_impl",
+]
+
+[[package]]
+name = "termcolor_output_impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34dde0bb841eb3762b42bdff8db11bbdbc0a3bd7b32012955f5ce1d081f86c1"
 
 [[package]]
 name = "thiserror"
@@ -9039,6 +10557,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9138,11 +10677,17 @@ dependencies = [
  "indexmap 2.14.1",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -9155,14 +10700,25 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.14.1",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.1",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -9171,7 +10727,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -9222,6 +10778,29 @@ dependencies = [
  "prost-types 0.13.5",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tonlib-core"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edcc99f835551a8a42cda992c834d4fc72e6b4420c9c78df4fc6e158d96e673"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bitstream-io",
+ "crc",
+ "hex",
+ "hmac",
+ "lazy_static",
+ "nacl",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "pbkdf2 0.12.2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9447,6 +11026,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "typify"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+dependencies = [
+ "heck 0.5.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars 0.8.22",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+ "thiserror 2.0.20",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars 0.8.22",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn 2.0.119",
+ "typify-impl",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9570,6 +11196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9621,6 +11253,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -9713,6 +11351,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmtimer"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9744,6 +11395,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.9",
 ]
 
 [[package]]
@@ -9919,6 +11579,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -10049,6 +11718,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -10061,6 +11739,9 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "writeable"
@@ -10069,12 +11750,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
+name = "wstd"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b52936db10a79bb724dadd1c2c3aac958e8229dcb1f1c7f2b7044ca9fc6a3a"
+dependencies = [
+ "anyhow",
+ "async-task",
+ "bytes",
+ "futures-lite",
+ "http 1.5.0",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "slab",
+ "wasip2",
+ "wstd-macro",
+]
+
+[[package]]
+name = "wstd-macro"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153db9b65508bf6c2efe26617169840c03671ba5719a35868db7682a5261f7d4"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]
@@ -10088,12 +11824,18 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
 ]
+
+[[package]]
+name = "xml-no-std"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
 
 [[package]]
 name = "xrpl-rust"
@@ -10104,7 +11846,7 @@ dependencies = [
  "bigdecimal",
  "bs58 0.5.1",
  "chrono",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "derive-new",
  "ed25519-dalek 2.2.0",
  "embassy-futures",

--- a/README.md
+++ b/README.md
@@ -190,8 +190,7 @@ Tron is `experimental-tron` and is not in the default image.
 | `svm` | ✓ | Parse Solana tables and construct `exact` and `upto` |
 | `telemetry` | ✓ | Reserved for OTLP |
 | `metrics` | ✓ | Enables `r402-facilitator/metrics` |
-| `near` / `xrpl` / `hedera` / `avm` | | Host `exact` when the feature is on |
-| `aptos` / `keeta` / `tvm` / `stellar` / `concordium` | | Compiled-out vs reserved family errors |
+| `near` / `xrpl` / `hedera` / `avm` / `aptos` / `keeta` / `tvm` / `stellar` / `concordium` | | Host `exact` when the feature is on |
 | `experimental-tron` | | Experimental; not in the default image |
 
 `casper:*` is always a remote-client startup error. There is no `extra-casper` feature.

--- a/config.example.full.toml
+++ b/config.example.full.toml
@@ -82,7 +82,8 @@ max_compute_unit_limit = 200000      # SolanaChainProvider::new; default 200_000
 # schemes = ["exact", "upto", "auth-capture", "batch-settlement"]
 
 # --- Other exact families (commented: not in the default image) ---
-# Rebuild with --features near,xrpl,hedera,avm. Casper is never hosted.
+# Rebuild with --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium.
+# Casper is never hosted.
 
 # [signer.near_relayer]
 # source = "env"
@@ -124,3 +125,75 @@ max_compute_unit_limit = 200000      # SolanaChainProvider::new; default 200_000
 # # algod_url = "https://testnet-api.algonode.cloud"
 # # algod_token_env = "ALGOD_TOKEN"   # independent of algod_url
 # # wait_rounds = 10
+
+# [signer.aptos_hot]
+# source = "file"
+# path = "/run/secrets/aptos.key"
+# encoding = "hex"                   # 32-byte Ed25519 private key
+#
+# [network."aptos:1"]
+# # rpc / rpc_env: at most one. Omit = SDK default fullnode.
+# # rpc = "https://fullnode.mainnet.aptoslabs.com/v1"
+# fee_payers = ["aptos_hot"]
+# schemes = ["exact"]
+# # sponsor_transactions = true      # provider default
+
+# [signer.keeta_hot]
+# source = "file"
+# path = "/run/secrets/keeta.key"
+# encoding = "base64"                # 32-byte ed25519 seed
+#
+# [network."keeta:1413829460"]        # testnet; mainnet keeta:21378
+# signer = "keeta_hot"
+# indices = [0]
+# schemes = ["exact"]
+# # no rpc / rpc_env — unknown fields
+
+# [signer.tvm_hot]
+# source = "file"
+# path = "/run/secrets/tvm.key"
+# encoding = "hex"                   # 32- or 64-byte Highload V3 key (hex or base64)
+#
+# [network."tvm:-3"]                 # testnet; mainnet tvm:-239
+# signer = "tvm_hot"
+# schemes = ["exact"]
+# # provider_base_url / rpc: at most one. Omit = Toncenter.
+# # rpc = "https://testnet.toncenter.com/api/v3"
+# # api_key_env = "TONCENTER_API_KEY"  # independent of the URL
+# # subwallet_id = 0x10ad             # default 4269
+# # timeout = 3600
+# # workchain = 0
+# # batch_flush_interval_seconds / batch_flush_size / confirmation_timeout_seconds
+# # are snake_case TOML mapped to TvmExactFacilitatorConfig (SDK type is camelCase).
+
+# [signer.stellar_hot]
+# source = "file"
+# path = "/run/secrets/stellar.key"
+# encoding = "utf8"                  # S + 55 base32
+#
+# [network."stellar:testnet"]
+# # rpc / rpc_env: at most one. Omit allowed on testnet. Pubnet requires one.
+# signers = ["stellar_hot"]
+# schemes = ["exact"]
+# # fee_bump = "stellar_hot"
+# # horizon_url = "https://horizon-testnet.stellar.org"
+# # max_transaction_fee_stroops = 50000
+#
+# [network."stellar:pubnet"]
+# rpc = "https://soroban.example"    # required: no public default
+# signers = ["stellar_hot"]
+# schemes = ["exact"]
+
+# [signer.ccd_hot]
+# source = "file"
+# path = "/run/secrets/ccd.key"
+# encoding = "hex"                   # 32-byte ed25519 seed
+#
+# [network."ccd:4221332d34e1694168c2a0c0b3fd0f27"]  # testnet genesis
+# # grpc / grpc_env: at most one. Omit = default_grpc_https().
+# # grpc = "https://grpc.testnet.concordium.com:20000"
+# signers = [{ address = "3UrcxPQeYywasrPcYUcqhvFu3SB2vBBDjj7TsaRQ431vGiczYp", signer = "ccd_hot" }]
+# schemes = ["exact"]
+# # require_finalization = true
+# # finalization_timeout = "60s"
+# # max_expiry_offset_seconds = 600

--- a/crates/facilitator/Cargo.toml
+++ b/crates/facilitator/Cargo.toml
@@ -30,11 +30,11 @@ near = ["dep:r402-near", "r402-near/facilitator"]
 xrpl = ["dep:r402-xrpl", "r402-xrpl/facilitator"]
 hedera = ["dep:r402-hedera", "r402-hedera/facilitator"]
 avm = ["dep:r402-avm", "r402-avm/facilitator"]
-aptos = []
-keeta = []
-tvm = []
-stellar = []
-concordium = []
+aptos = ["dep:r402-aptos", "r402-aptos/facilitator"]
+keeta = ["dep:r402-keeta", "r402-keeta/facilitator", "dep:base64"]
+tvm = ["dep:r402-tvm", "r402-tvm/facilitator"]
+stellar = ["dep:r402-stellar", "r402-stellar/facilitator"]
+concordium = ["dep:r402-concordium", "r402-concordium/facilitator"]
 experimental-tron = []
 telemetry = [
     "r402-evm?/telemetry",
@@ -43,6 +43,11 @@ telemetry = [
     "r402-xrpl?/telemetry",
     "r402-hedera?/telemetry",
     "r402-avm?/telemetry",
+    "r402-aptos?/telemetry",
+    "r402-keeta?/telemetry",
+    "r402-tvm?/telemetry",
+    "r402-stellar?/telemetry",
+    "r402-concordium?/telemetry",
 ]
 metrics = ["dep:metrics", "dep:metrics-exporter-prometheus", "r402-facilitator/metrics"]
 
@@ -51,6 +56,7 @@ alloy-network = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 axum = { workspace = true }
+base64 = { version = "0.23", optional = true }
 clap = { workspace = true }
 compact_str = { workspace = true }
 humantime-serde = { workspace = true }
@@ -77,6 +83,11 @@ r402-near = { version = "0.19.1", path = "../../../r402/crates/r402-near", defau
 r402-xrpl = { version = "0.19.1", path = "../../../r402/crates/r402-xrpl", default-features = false, optional = true }
 r402-hedera = { version = "0.19.1", path = "../../../r402/crates/r402-hedera", default-features = false, optional = true }
 r402-avm = { version = "0.19.1", path = "../../../r402/crates/r402-avm", default-features = false, optional = true }
+r402-aptos = { version = "0.19.1", path = "../../../r402/crates/r402-aptos", default-features = false, optional = true }
+r402-keeta = { version = "0.19.1", path = "../../../r402/crates/r402-keeta", default-features = false, optional = true }
+r402-tvm = { version = "0.19.1", path = "../../../r402/crates/r402-tvm", default-features = false, optional = true }
+r402-stellar = { version = "0.19.1", path = "../../../r402/crates/r402-stellar", default-features = false, optional = true }
+r402-concordium = { version = "0.19.1", path = "../../../r402/crates/r402-concordium", default-features = false, optional = true }
 solana-keypair = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/facilitator/src/compose/aptos.rs
+++ b/crates/facilitator/src/compose/aptos.rs
@@ -1,0 +1,85 @@
+//! Aptos provider + exact facilitator wiring.
+
+use std::sync::Arc;
+
+use compact_str::CompactString;
+use r402_aptos::chain::AptosChainReference;
+use r402_aptos::{AptosChainProvider, AptosExactFacilitator, AptosFeePayer};
+use r402_facilitator::SettlementCache;
+use r402_protocol::ExactScheme;
+use r402_protocol::scheme::SchemeSlug;
+
+use super::{FacilitatorMap, named_secret, scheme_not_enabled};
+use crate::config::{AptosNetwork, Config, resolve_optional_rpc};
+use crate::error::Error;
+
+/// Register Aptos exact for `network`.
+pub(super) fn register(
+    map: &mut FacilitatorMap,
+    network: &AptosNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+    cache: &SettlementCache,
+) -> Result<(), Error> {
+    let provider = provider(network, config, lookup)?;
+    let sponsor = provider.sponsor_transactions();
+    for name in &network.schemes {
+        match name.as_str() {
+            ExactScheme::VALUE => {
+                let facilitator = AptosExactFacilitator::with_settlement_cache(
+                    provider.clone(),
+                    sponsor,
+                    cache.clone(),
+                );
+                insert_scheme(map, network, ExactScheme::VALUE, facilitator)?;
+            }
+            _ => return Err(scheme_not_enabled(name, &network.chain_id)),
+        }
+    }
+    Ok(())
+}
+
+fn provider(
+    network: &AptosNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<AptosChainProvider, Error> {
+    let chain = AptosChainReference::try_from(network.chain_id.clone()).map_err(|err| {
+        Error::config_with(
+            format!("invalid Aptos chain id '{}'", network.chain_id),
+            err,
+        )
+    })?;
+    let rpc_url = resolve_optional_rpc(&network.chain_id, network.rpc.as_ref(), lookup)?;
+    let mut fee_payers = Vec::with_capacity(network.fee_payers.len());
+    for name in &network.fee_payers {
+        let secret = named_secret(config, name, lookup)?;
+        fee_payers.push(AptosFeePayer::from_private_key_hex(&secret).map_err(|err| {
+            Error::config_with(
+                format!("signer '{name}' is not a valid Aptos private key"),
+                err,
+            )
+        })?);
+    }
+    let provider =
+        AptosChainProvider::new(chain, fee_payers, rpc_url.as_deref()).map_err(|err| {
+            Error::config_with(
+                format!(
+                    "failed to build AptosChainProvider for '{}'",
+                    network.chain_id
+                ),
+                err,
+            )
+        })?;
+    Ok(provider.with_sponsor_transactions(network.sponsor_transactions))
+}
+
+fn insert_scheme(
+    map: &mut FacilitatorMap,
+    network: &AptosNetwork,
+    name: &'static str,
+    handler: AptosExactFacilitator<AptosChainProvider>,
+) -> Result<(), Error> {
+    let slug = SchemeSlug::new(network.chain_id.clone(), CompactString::from(name));
+    map.insert(slug, Arc::new(handler))
+}

--- a/crates/facilitator/src/compose/concordium.rs
+++ b/crates/facilitator/src/compose/concordium.rs
@@ -1,0 +1,104 @@
+//! Concordium provider + exact facilitator wiring.
+
+use std::sync::Arc;
+
+use compact_str::CompactString;
+use r402_concordium::chain::ConcordiumChainReference;
+use r402_concordium::{
+    ConcordiumChainProvider, ConcordiumExactFacilitator, ConcordiumGrpc, ConcordiumSigner,
+};
+use r402_facilitator::SettlementCache;
+use r402_protocol::ExactScheme;
+use r402_protocol::scheme::SchemeSlug;
+
+use super::{FacilitatorMap, named_secret, scheme_not_enabled};
+use crate::config::{ConcordiumNetwork, Config, resolve_optional_grpc};
+use crate::error::Error;
+
+/// Register Concordium exact for `network`.
+///
+/// [`ConcordiumChainProvider::connect`] dials gRPC. Tests that must not
+/// talk to a node should parse only.
+pub(super) async fn register(
+    map: &mut FacilitatorMap,
+    network: &ConcordiumNetwork,
+    config: &Config,
+    lookup: &(impl Fn(&str) -> Option<String> + Send + Sync),
+    cache: &SettlementCache,
+) -> Result<(), Error> {
+    for name in &network.schemes {
+        if name.as_str() != ExactScheme::VALUE {
+            return Err(scheme_not_enabled(name, &network.chain_id));
+        }
+    }
+    let provider = provider(network, config, lookup).await?;
+    let mut facilitator = ConcordiumExactFacilitator::try_new(provider)
+        .map_err(|err| {
+            Error::config_with(
+                format!(
+                    "failed to construct ConcordiumExactFacilitator for '{}'",
+                    network.chain_id
+                ),
+                err,
+            )
+        })?
+        .with_settlement_cache(cache.clone());
+    facilitator = facilitator.with_require_finalization(network.require_finalization);
+    if let Some(timeout) = network.finalization_timeout {
+        facilitator = facilitator.with_finalization_timeout(timeout);
+    }
+    if let Some(offset) = network.max_expiry_offset_seconds {
+        facilitator = facilitator.with_max_expiry_offset_seconds(offset);
+    }
+    insert_scheme(map, network, ExactScheme::VALUE, facilitator)
+}
+
+async fn provider(
+    network: &ConcordiumNetwork,
+    config: &Config,
+    lookup: &(impl Fn(&str) -> Option<String> + Send + Sync),
+) -> Result<ConcordiumChainProvider, Error> {
+    let chain = ConcordiumChainReference::try_from(network.chain_id.clone()).map_err(|err| {
+        Error::config_with(
+            format!("invalid Concordium chain id '{}'", network.chain_id),
+            err,
+        )
+    })?;
+    let grpc_url = resolve_optional_grpc(&network.chain_id, network.grpc.as_ref(), lookup)?;
+    let mut signers = Vec::with_capacity(network.signers.len());
+    for account in &network.signers {
+        let secret = named_secret(config, &account.signer, lookup)?;
+        signers.push(
+            ConcordiumSigner::from_secret(&account.address, secret).map_err(|err| {
+                Error::config_with(
+                    format!(
+                        "signer '{}' is not a valid Concordium address+seed",
+                        account.signer
+                    ),
+                    err,
+                )
+            })?,
+        );
+    }
+    ConcordiumChainProvider::connect(chain, signers, grpc_url)
+        .await
+        .map_err(|err| {
+            Error::config_with(
+                format!(
+                    "failed to connect Concordium gRPC for '{}'",
+                    network.chain_id
+                ),
+                err,
+            )
+        })
+}
+
+fn insert_scheme(
+    map: &mut FacilitatorMap,
+    network: &ConcordiumNetwork,
+    name: &'static str,
+    handler: ConcordiumExactFacilitator<ConcordiumGrpc>,
+) -> Result<(), Error> {
+    let slug = SchemeSlug::new(network.chain_id.clone(), CompactString::from(name));
+    map.insert(slug, Arc::new(handler))
+}

--- a/crates/facilitator/src/compose/keeta.rs
+++ b/crates/facilitator/src/compose/keeta.rs
@@ -1,0 +1,114 @@
+//! Keeta provider + exact facilitator wiring.
+
+use std::sync::Arc;
+
+use base64::Engine;
+use compact_str::CompactString;
+use r402_facilitator::SettlementCache;
+use r402_keeta::KeetaExactFacilitator;
+use r402_keeta::chain::{KeetaChainProvider, KeetaChainReference, KeetaFeePayer};
+use r402_keeta::exact::facilitator::SettlementQueue;
+use r402_protocol::ExactScheme;
+use r402_protocol::scheme::SchemeSlug;
+
+use super::{FacilitatorMap, named_secret, scheme_not_enabled};
+use crate::config::{Config, KeetaNetwork};
+use crate::error::Error;
+
+/// Register Keeta exact for `network`.
+pub(super) fn register(
+    map: &mut FacilitatorMap,
+    network: &KeetaNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+    cache: &SettlementCache,
+) -> Result<(), Error> {
+    let provider = provider(network, config, lookup)?;
+    for name in &network.schemes {
+        match name.as_str() {
+            ExactScheme::VALUE => {
+                // Duplicate try_new's queue construction so the process cache is shared.
+                let accounts = provider
+                    .fee_payers()
+                    .iter()
+                    .map(|payer| Arc::clone(payer.account()))
+                    .collect();
+                let queue =
+                    SettlementQueue::new(accounts, provider.chain_reference().client_network());
+                let facilitator = KeetaExactFacilitator::with_settlement_cache(
+                    provider.clone(),
+                    queue,
+                    cache.clone(),
+                );
+                insert_scheme(map, network, ExactScheme::VALUE, facilitator)?;
+            }
+            _ => return Err(scheme_not_enabled(name, &network.chain_id)),
+        }
+    }
+    Ok(())
+}
+
+fn provider(
+    network: &KeetaNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<KeetaChainProvider, Error> {
+    let chain = KeetaChainReference::try_from(network.chain_id.clone()).map_err(|err| {
+        Error::config_with(
+            format!("invalid Keeta chain id '{}'", network.chain_id),
+            err,
+        )
+    })?;
+    let secret = named_secret(config, &network.signer, lookup)?;
+    let seed = keeta_seed(&network.signer, &secret)?;
+    let mut fee_payers = Vec::with_capacity(network.indices.len());
+    for index in &network.indices {
+        fee_payers.push(
+            KeetaFeePayer::from_ed25519_seed(seed, *index).map_err(|err| {
+                Error::config_with(
+                    format!(
+                        "signer '{}' index {index} is not a valid Keeta ed25519 seed",
+                        network.signer
+                    ),
+                    err,
+                )
+            })?,
+        );
+    }
+    KeetaChainProvider::new(chain, fee_payers).map_err(|err| {
+        Error::config_with(
+            format!(
+                "failed to build KeetaChainProvider for '{}'",
+                network.chain_id
+            ),
+            err,
+        )
+    })
+}
+
+fn keeta_seed(name: &str, secret: &str) -> Result<[u8; 32], Error> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(secret.trim())
+        .map_err(|err| {
+            Error::config_with(
+                format!("signer '{name}' is not a valid Keeta base64 seed"),
+                err,
+            )
+        })?;
+    <[u8; 32]>::try_from(bytes).map_err(|bytes| {
+        Error::config(format!(
+            "signer '{name}' is not a valid Keeta base64 seed (decoded {} bytes, expected 32)",
+            bytes.len()
+        ))
+    })
+}
+
+fn insert_scheme(
+    map: &mut FacilitatorMap,
+    network: &KeetaNetwork,
+    name: &'static str,
+    handler: KeetaExactFacilitator<KeetaChainProvider>,
+) -> Result<(), Error> {
+    let slug = SchemeSlug::new(network.chain_id.clone(), CompactString::from(name));
+    map.insert(slug, Arc::new(handler))
+}

--- a/crates/facilitator/src/compose/mod.rs
+++ b/crates/facilitator/src/compose/mod.rs
@@ -1,15 +1,25 @@
 //! Private `FacilitatorMap` dispatching by `SchemeSlug`.
 
+#[cfg(feature = "aptos")]
+mod aptos;
 #[cfg(feature = "avm")]
 mod avm;
+#[cfg(feature = "concordium")]
+mod concordium;
 #[cfg(feature = "evm")]
 mod evm;
 #[cfg(feature = "hedera")]
 mod hedera;
+#[cfg(feature = "keeta")]
+mod keeta;
 #[cfg(feature = "near")]
 mod near;
+#[cfg(feature = "stellar")]
+mod stellar;
 #[cfg(feature = "svm")]
 mod svm;
+#[cfg(feature = "tvm")]
+mod tvm;
 #[cfg(feature = "xrpl")]
 mod xrpl;
 
@@ -17,7 +27,17 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use compact_str::CompactString;
-#[cfg(any(feature = "evm", feature = "svm", feature = "hedera", feature = "avm"))]
+#[cfg(any(
+    feature = "evm",
+    feature = "svm",
+    feature = "hedera",
+    feature = "avm",
+    feature = "aptos",
+    feature = "keeta",
+    feature = "tvm",
+    feature = "stellar",
+    feature = "concordium"
+))]
 use r402_facilitator::SettlementCache;
 use r402_facilitator::{DynFacilitator, Facilitator};
 #[cfg(any(feature = "evm", feature = "svm"))]
@@ -122,14 +142,15 @@ impl Facilitator for FacilitatorMap {
 ///
 /// EVM exact/upto and SVM exact use `with_settlement_cache` as a constructor
 /// (never `try_new`) so they share the process
-/// [`r402_facilitator::SettlementCache`]. Hedera and AVM exact share that
-/// cache too. NEAR and XRPL use private cache types (one per process).
-/// SVM upto uses `new`, `with_storage`, and `with_pending_store` (no
-/// settlement-cache constructor; r402 0.19.1 has no rent-cleanup manager).
-/// Auth-capture uses `try_new(provider)` only. Batch-settlement uses
-/// `with_store` with a process-wide in-memory channel store. Path 2 is a
-/// startup error. A listed scheme without a constructor in this build is an
-/// error. The returned map is nonempty.
+/// [`r402_facilitator::SettlementCache`]. Hedera, AVM, Aptos, Keeta, TVM,
+/// Stellar, and Concordium exact share that cache too. NEAR and XRPL use
+/// private cache types (one per process). SVM upto uses `new`,
+/// `with_storage`, and `with_pending_store` (no settlement-cache constructor;
+/// r402 0.19.1 has no rent-cleanup manager). Auth-capture uses
+/// `try_new(provider)` only. Batch-settlement uses `with_store` with a
+/// process-wide in-memory channel store. Path 2 is a startup error. A listed
+/// scheme without a constructor in this build is an error. The returned map
+/// is nonempty.
 ///
 /// # Errors
 ///
@@ -140,7 +161,17 @@ pub async fn build(
     lookup: &(impl Fn(&str) -> Option<String> + Send + Sync),
 ) -> Result<FacilitatorMap, Error> {
     let mut map = FacilitatorMap::new();
-    #[cfg(any(feature = "evm", feature = "svm", feature = "hedera", feature = "avm"))]
+    #[cfg(any(
+        feature = "evm",
+        feature = "svm",
+        feature = "hedera",
+        feature = "avm",
+        feature = "aptos",
+        feature = "keeta",
+        feature = "tvm",
+        feature = "stellar",
+        feature = "concordium"
+    ))]
     let cache = SettlementCache::new();
     #[cfg(any(feature = "evm", feature = "svm"))]
     let pending: Arc<dyn PendingSettlementStore> = Arc::new(InMemoryPendingSettlementStore::new());
@@ -158,7 +189,15 @@ pub async fn build(
     let xrpl_cache = r402_xrpl::exact::facilitator::XrplSettlementCache::new();
     #[cfg(all(
         any(feature = "evm", feature = "svm"),
-        not(any(feature = "hedera", feature = "avm"))
+        not(any(
+            feature = "hedera",
+            feature = "avm",
+            feature = "aptos",
+            feature = "keeta",
+            feature = "tvm",
+            feature = "stellar",
+            feature = "concordium"
+        ))
     ))]
     drop(cache);
     #[cfg(any(feature = "evm", feature = "svm"))]
@@ -197,6 +236,26 @@ pub async fn build(
             Network::Avm(net) => {
                 avm::register(&mut map, net, config, lookup, &cache)?;
             }
+            #[cfg(feature = "aptos")]
+            Network::Aptos(net) => {
+                aptos::register(&mut map, net, config, lookup, &cache)?;
+            }
+            #[cfg(feature = "keeta")]
+            Network::Keeta(net) => {
+                keeta::register(&mut map, net, config, lookup, &cache)?;
+            }
+            #[cfg(feature = "tvm")]
+            Network::Tvm(net) => {
+                tvm::register(&mut map, net, config, lookup, &cache)?;
+            }
+            #[cfg(feature = "stellar")]
+            Network::Stellar(net) => {
+                stellar::register(&mut map, net, config, lookup, &cache)?;
+            }
+            #[cfg(feature = "concordium")]
+            Network::Concordium(net) => {
+                concordium::register(&mut map, net, config, lookup, &cache).await?;
+            }
         }
     }
     #[cfg(feature = "evm")]
@@ -211,7 +270,12 @@ pub async fn build(
     feature = "svm",
     feature = "near",
     feature = "hedera",
-    feature = "avm"
+    feature = "avm",
+    feature = "aptos",
+    feature = "keeta",
+    feature = "tvm",
+    feature = "stellar",
+    feature = "concordium"
 ))]
 pub(super) fn named_secret(
     config: &Config,

--- a/crates/facilitator/src/compose/stellar.rs
+++ b/crates/facilitator/src/compose/stellar.rs
@@ -1,0 +1,102 @@
+//! Stellar provider + exact facilitator wiring.
+
+use std::sync::Arc;
+
+use compact_str::CompactString;
+use r402_facilitator::SettlementCache;
+use r402_protocol::ExactScheme;
+use r402_protocol::scheme::SchemeSlug;
+use r402_stellar::chain::StellarChainReference;
+use r402_stellar::{StellarChainProvider, StellarExactFacilitator, StellarSigner};
+
+use super::{FacilitatorMap, named_secret, scheme_not_enabled};
+use crate::config::{Config, StellarNetwork, resolve_optional_rpc};
+use crate::error::Error;
+
+/// Register Stellar exact for `network`.
+pub(super) fn register(
+    map: &mut FacilitatorMap,
+    network: &StellarNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+    cache: &SettlementCache,
+) -> Result<(), Error> {
+    let provider = provider(network, config, lookup)?;
+    let max_fee = provider.max_transaction_fee_stroops();
+    for name in &network.schemes {
+        match name.as_str() {
+            ExactScheme::VALUE => {
+                let facilitator = StellarExactFacilitator::with_settlement_cache(
+                    provider.clone(),
+                    max_fee,
+                    cache.clone(),
+                );
+                insert_scheme(map, network, ExactScheme::VALUE, facilitator)?;
+            }
+            _ => return Err(scheme_not_enabled(name, &network.chain_id)),
+        }
+    }
+    Ok(())
+}
+
+fn provider(
+    network: &StellarNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<StellarChainProvider, Error> {
+    let chain = StellarChainReference::try_from(network.chain_id.clone()).map_err(|err| {
+        Error::config_with(
+            format!("invalid Stellar chain id '{}'", network.chain_id),
+            err,
+        )
+    })?;
+    let rpc_url = resolve_optional_rpc(&network.chain_id, network.rpc.as_ref(), lookup)?;
+    let mut signers = Vec::with_capacity(network.signers.len());
+    for name in &network.signers {
+        signers.push(stellar_signer(config, name, lookup)?);
+    }
+    let mut provider =
+        StellarChainProvider::new(chain, signers, rpc_url.as_deref()).map_err(|err| {
+            Error::config_with(
+                format!(
+                    "failed to build StellarChainProvider for '{}'",
+                    network.chain_id
+                ),
+                err,
+            )
+        })?;
+    if let Some(url) = &network.horizon_url {
+        provider = provider.with_horizon_url(url.as_str());
+    }
+    if let Some(fee) = network.max_transaction_fee_stroops {
+        provider = provider.with_max_transaction_fee_stroops(fee);
+    }
+    if let Some(name) = &network.fee_bump {
+        provider = provider.with_fee_bump_signer(stellar_signer(config, name, lookup)?);
+    }
+    Ok(provider)
+}
+
+fn stellar_signer(
+    config: &Config,
+    name: &str,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<StellarSigner, Error> {
+    let secret = named_secret(config, name, lookup)?;
+    StellarSigner::from_secret(&secret).map_err(|err| {
+        Error::config_with(
+            format!("signer '{name}' is not a valid Stellar secret key"),
+            err,
+        )
+    })
+}
+
+fn insert_scheme(
+    map: &mut FacilitatorMap,
+    network: &StellarNetwork,
+    name: &'static str,
+    handler: StellarExactFacilitator<StellarChainProvider>,
+) -> Result<(), Error> {
+    let slug = SchemeSlug::new(network.chain_id.clone(), CompactString::from(name));
+    map.insert(slug, Arc::new(handler))
+}

--- a/crates/facilitator/src/compose/tvm.rs
+++ b/crates/facilitator/src/compose/tvm.rs
@@ -1,0 +1,97 @@
+//! TVM provider + exact facilitator wiring.
+
+use std::sync::Arc;
+
+use compact_str::CompactString;
+use r402_facilitator::SettlementCache;
+use r402_protocol::ExactScheme;
+use r402_protocol::scheme::SchemeSlug;
+use r402_tvm::chain::TvmChainReference;
+use r402_tvm::exact::facilitator::TvmExactFacilitatorConfig;
+use r402_tvm::{HighloadV3Config, TvmChainProvider, TvmExactFacilitator};
+
+use super::{FacilitatorMap, named_secret, scheme_not_enabled};
+use crate::config::{Config, TvmNetwork, resolve_api_key};
+use crate::error::Error;
+
+/// Register TVM exact for `network`.
+pub(super) fn register(
+    map: &mut FacilitatorMap,
+    network: &TvmNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+    cache: &SettlementCache,
+) -> Result<(), Error> {
+    let provider = provider(network, config, lookup)?;
+    let cfg = TvmExactFacilitatorConfig {
+        batch_flush_interval_seconds: network.batch_flush_interval_seconds,
+        batch_flush_size: network.batch_flush_size,
+        confirmation_timeout_seconds: network.confirmation_timeout_seconds,
+    };
+    for name in &network.schemes {
+        match name.as_str() {
+            ExactScheme::VALUE => {
+                let facilitator = TvmExactFacilitator::with_settlement_cache(
+                    provider.clone(),
+                    cfg,
+                    cache.clone(),
+                );
+                insert_scheme(map, network, ExactScheme::VALUE, facilitator)?;
+            }
+            _ => return Err(scheme_not_enabled(name, &network.chain_id)),
+        }
+    }
+    Ok(())
+}
+
+fn provider(
+    network: &TvmNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<TvmChainProvider, Error> {
+    let chain = TvmChainReference::try_from(network.chain_id.clone()).map_err(|err| {
+        Error::config_with(format!("invalid TVM chain id '{}'", network.chain_id), err)
+    })?;
+    let secret = named_secret(config, &network.signer, lookup)?;
+    let mut hl = HighloadV3Config::from_private_key_str(&secret).map_err(|err| {
+        Error::config_with(
+            format!(
+                "signer '{}' is not a valid TVM Highload V3 private key",
+                network.signer
+            ),
+            err,
+        )
+    })?;
+    if let Some(url) = &network.provider_base_url {
+        hl.provider_base_url = Some(url.as_str().to_owned());
+    }
+    hl.api_key = resolve_api_key(&network.chain_id, network.api_key_env.as_deref(), lookup)?;
+    if let Some(id) = network.subwallet_id {
+        hl.subwallet_id = id;
+    }
+    if let Some(timeout) = network.timeout {
+        hl.timeout = timeout;
+    }
+    if let Some(workchain) = network.workchain {
+        hl.workchain = workchain;
+    }
+    TvmChainProvider::new(chain, hl).map_err(|err| {
+        Error::config_with(
+            format!(
+                "failed to build TvmChainProvider for '{}'",
+                network.chain_id
+            ),
+            err,
+        )
+    })
+}
+
+fn insert_scheme(
+    map: &mut FacilitatorMap,
+    network: &TvmNetwork,
+    name: &'static str,
+    handler: TvmExactFacilitator,
+) -> Result<(), Error> {
+    let slug = SchemeSlug::new(network.chain_id.clone(), CompactString::from(name));
+    map.insert(slug, Arc::new(handler))
+}

--- a/crates/facilitator/src/config/family.rs
+++ b/crates/facilitator/src/config/family.rs
@@ -6,7 +6,12 @@
     feature = "near",
     feature = "xrpl",
     feature = "hedera",
-    feature = "avm"
+    feature = "avm",
+    feature = "aptos",
+    feature = "keeta",
+    feature = "tvm",
+    feature = "stellar",
+    feature = "concordium"
 ))]
 use r402_protocol::scheme::SchemeId;
 
@@ -56,6 +61,21 @@ pub(crate) enum HostableFamily {
     /// Algorand / AVM.
     #[cfg(feature = "avm")]
     Avm,
+    /// Aptos.
+    #[cfg(feature = "aptos")]
+    Aptos,
+    /// Keeta.
+    #[cfg(feature = "keeta")]
+    Keeta,
+    /// TON / TVM.
+    #[cfg(feature = "tvm")]
+    Tvm,
+    /// Stellar.
+    #[cfg(feature = "stellar")]
+    Stellar,
+    /// Concordium (`ccd`).
+    #[cfg(feature = "concordium")]
+    Concordium,
 }
 
 /// Namespace string for EIP-155, from the SDK when the `evm` feature is on.
@@ -146,6 +166,79 @@ fn algorand_namespace() -> &'static str {
     }
 }
 
+/// Namespace string for Aptos.
+#[allow(
+    clippy::missing_const_for_fn,
+    reason = "feature-on branch calls SchemeId::namespace, which is not const"
+)]
+fn aptos_namespace() -> &'static str {
+    #[cfg(feature = "aptos")]
+    {
+        r402_aptos::AptosExact.namespace()
+    }
+    #[cfg(not(feature = "aptos"))]
+    {
+        "aptos"
+    }
+}
+
+/// Namespace string for Keeta.
+#[allow(
+    clippy::missing_const_for_fn,
+    reason = "feature-on branch calls SchemeId::namespace, which is not const"
+)]
+fn keeta_namespace() -> &'static str {
+    #[cfg(feature = "keeta")]
+    {
+        r402_keeta::KeetaExact.namespace()
+    }
+    #[cfg(not(feature = "keeta"))]
+    {
+        "keeta"
+    }
+}
+
+/// Namespace string for TON (`tvm`, not `ton`).
+#[allow(
+    clippy::missing_const_for_fn,
+    reason = "feature-on branch calls SchemeId::namespace, which is not const"
+)]
+fn tvm_namespace() -> &'static str {
+    #[cfg(feature = "tvm")]
+    {
+        r402_tvm::TvmExact.namespace()
+    }
+    #[cfg(not(feature = "tvm"))]
+    {
+        "tvm"
+    }
+}
+
+/// Namespace string for Stellar.
+#[allow(
+    clippy::missing_const_for_fn,
+    reason = "feature-on branch calls SchemeId::namespace, which is not const"
+)]
+fn stellar_namespace() -> &'static str {
+    #[cfg(feature = "stellar")]
+    {
+        r402_stellar::StellarExact.namespace()
+    }
+    #[cfg(not(feature = "stellar"))]
+    {
+        "stellar"
+    }
+}
+
+/// Namespace string for Concordium (`ccd`).
+///
+/// `ConcordiumExact` is not `Copy` and `SchemeId::namespace` is `&str`, so the
+/// SDK call cannot be returned as `'static`. The hostable unit test pins this
+/// against `ConcordiumExact::new().namespace()`.
+const fn ccd_namespace() -> &'static str {
+    "ccd"
+}
+
 /// Cargo feature name for a known CAIP-2 namespace.
 #[must_use]
 pub(crate) fn family_feature(namespace: &str) -> Option<&'static str> {
@@ -167,12 +260,22 @@ pub(crate) fn family_feature(namespace: &str) -> Option<&'static str> {
     if namespace == algorand_namespace() {
         return Some("avm");
     }
+    if namespace == aptos_namespace() {
+        return Some("aptos");
+    }
+    if namespace == keeta_namespace() {
+        return Some("keeta");
+    }
+    if namespace == tvm_namespace() {
+        return Some("tvm");
+    }
+    if namespace == stellar_namespace() {
+        return Some("stellar");
+    }
+    if namespace == ccd_namespace() {
+        return Some("concordium");
+    }
     match namespace {
-        "aptos" => Some("aptos"),
-        "keeta" => Some("keeta"),
-        "tvm" => Some("tvm"),
-        "stellar" => Some("stellar"),
-        "ccd" => Some("concordium"),
         "tron" => Some("experimental-tron"),
         _ => None,
     }
@@ -234,6 +337,26 @@ pub(crate) fn classify(namespace: &str) -> FamilyStatus {
     #[cfg(feature = "avm")]
     if namespace == algorand_namespace() {
         return FamilyStatus::Hostable(HostableFamily::Avm);
+    }
+    #[cfg(feature = "aptos")]
+    if namespace == aptos_namespace() {
+        return FamilyStatus::Hostable(HostableFamily::Aptos);
+    }
+    #[cfg(feature = "keeta")]
+    if namespace == keeta_namespace() {
+        return FamilyStatus::Hostable(HostableFamily::Keeta);
+    }
+    #[cfg(feature = "tvm")]
+    if namespace == tvm_namespace() {
+        return FamilyStatus::Hostable(HostableFamily::Tvm);
+    }
+    #[cfg(feature = "stellar")]
+    if namespace == stellar_namespace() {
+        return FamilyStatus::Hostable(HostableFamily::Stellar);
+    }
+    #[cfg(feature = "concordium")]
+    if namespace == ccd_namespace() {
+        return FamilyStatus::Hostable(HostableFamily::Concordium);
     }
     FamilyStatus::Reserved { feature }
 }
@@ -346,13 +469,107 @@ mod tests {
         assert_eq!(algorand_namespace(), r402_avm::AlgorandExact.namespace());
     }
 
+    #[cfg(not(feature = "aptos"))]
     #[test]
-    fn aptos_compiled_out_or_reserved() {
-        match classify("aptos") {
-            FamilyStatus::CompiledOut { feature } | FamilyStatus::Reserved { feature } => {
-                assert_eq!(feature, "aptos", "feature name");
+    fn aptos_compiled_out() {
+        assert_eq!(
+            classify("aptos"),
+            FamilyStatus::CompiledOut { feature: "aptos" }
+        );
+    }
+
+    #[cfg(feature = "aptos")]
+    #[test]
+    fn aptos_hostable() {
+        assert_eq!(
+            classify("aptos"),
+            FamilyStatus::Hostable(HostableFamily::Aptos)
+        );
+        assert_eq!(aptos_namespace(), r402_aptos::AptosExact.namespace());
+    }
+
+    #[cfg(not(feature = "keeta"))]
+    #[test]
+    fn keeta_compiled_out() {
+        assert_eq!(
+            classify("keeta"),
+            FamilyStatus::CompiledOut { feature: "keeta" }
+        );
+    }
+
+    #[cfg(feature = "keeta")]
+    #[test]
+    fn keeta_hostable() {
+        assert_eq!(
+            classify("keeta"),
+            FamilyStatus::Hostable(HostableFamily::Keeta)
+        );
+        assert_eq!(keeta_namespace(), r402_keeta::KeetaExact.namespace());
+    }
+
+    #[cfg(not(feature = "tvm"))]
+    #[test]
+    fn tvm_compiled_out() {
+        assert_eq!(
+            classify("tvm"),
+            FamilyStatus::CompiledOut { feature: "tvm" }
+        );
+        assert_eq!(
+            classify("ton"),
+            FamilyStatus::Unknown,
+            "TVM namespace is tvm, not ton"
+        );
+    }
+
+    #[cfg(feature = "tvm")]
+    #[test]
+    fn tvm_hostable() {
+        assert_eq!(classify("tvm"), FamilyStatus::Hostable(HostableFamily::Tvm));
+        assert_eq!(tvm_namespace(), r402_tvm::TvmExact.namespace());
+        assert_eq!(tvm_namespace(), "tvm", "not ton");
+        assert_eq!(classify("ton"), FamilyStatus::Unknown);
+    }
+
+    #[cfg(not(feature = "stellar"))]
+    #[test]
+    fn stellar_compiled_out() {
+        assert_eq!(
+            classify("stellar"),
+            FamilyStatus::CompiledOut { feature: "stellar" }
+        );
+    }
+
+    #[cfg(feature = "stellar")]
+    #[test]
+    fn stellar_hostable() {
+        assert_eq!(
+            classify("stellar"),
+            FamilyStatus::Hostable(HostableFamily::Stellar)
+        );
+        assert_eq!(stellar_namespace(), r402_stellar::StellarExact.namespace());
+    }
+
+    #[cfg(not(feature = "concordium"))]
+    #[test]
+    fn ccd_compiled_out() {
+        assert_eq!(
+            classify("ccd"),
+            FamilyStatus::CompiledOut {
+                feature: "concordium"
             }
-            other => panic!("expected compiled-out or reserved, got {other:?}"),
-        }
+        );
+    }
+
+    #[cfg(feature = "concordium")]
+    #[test]
+    fn ccd_hostable() {
+        assert_eq!(
+            classify("ccd"),
+            FamilyStatus::Hostable(HostableFamily::Concordium)
+        );
+        assert_eq!(
+            ccd_namespace(),
+            r402_concordium::ConcordiumExact::new().namespace()
+        );
     }
 }

--- a/crates/facilitator/src/config/mod.rs
+++ b/crates/facilitator/src/config/mod.rs
@@ -14,19 +14,40 @@ use std::str::FromStr;
 use family::{CASPER_UNHOSTABLE, FamilyStatus, classify};
 pub use http::{HttpAuth, HttpConfig, LogConfig, LogFormat};
 use literal::{reject_literals_and_obsolete, reject_obsolete_root};
+#[cfg(feature = "aptos")]
+pub use network::AptosNetwork;
 #[cfg(feature = "avm")]
 pub use network::AvmNetwork;
+#[cfg(feature = "concordium")]
+pub use network::ConcordiumAccount;
+#[cfg(feature = "keeta")]
+pub use network::KeetaNetwork;
 #[cfg(any(feature = "near", feature = "hedera"))]
 pub use network::NamedAccount;
 #[cfg(feature = "near")]
 pub use network::NearNetwork;
+#[cfg(feature = "stellar")]
+pub use network::StellarNetwork;
+#[cfg(feature = "tvm")]
+pub use network::TvmNetwork;
 #[cfg(feature = "xrpl")]
 pub use network::XrplNetwork;
 #[cfg(feature = "avm")]
 pub(crate) use network::resolve_algod_token;
-#[cfg(any(feature = "near", feature = "xrpl"))]
+#[cfg(feature = "tvm")]
+pub(crate) use network::resolve_api_key;
+#[cfg(feature = "concordium")]
+pub(crate) use network::resolve_optional_grpc;
+#[cfg(any(
+    feature = "near",
+    feature = "xrpl",
+    feature = "aptos",
+    feature = "stellar"
+))]
 pub(crate) use network::resolve_optional_rpc;
 pub(crate) use network::resolve_rpc;
+#[cfg(feature = "concordium")]
+pub use network::{ConcordiumNetwork, GrpcConfig};
 pub use network::{EvmNetwork, Network, RpcConfig, RpcEndpoint, SvmNetwork};
 #[cfg(feature = "hedera")]
 pub use network::{HederaAliasPolicy, HederaNetwork};
@@ -354,6 +375,24 @@ fn resolve_network_env(
         #[cfg(feature = "avm")]
         Network::Avm(net) => {
             let _ = resolve_algod_token(&net.chain_id, net.algod_token_env.as_deref(), lookup)?;
+        }
+        #[cfg(feature = "aptos")]
+        Network::Aptos(net) => {
+            let _ = resolve_optional_rpc(&net.chain_id, net.rpc.as_ref(), lookup)?;
+        }
+        #[cfg(feature = "keeta")]
+        Network::Keeta(_) => {}
+        #[cfg(feature = "tvm")]
+        Network::Tvm(net) => {
+            let _ = resolve_api_key(&net.chain_id, net.api_key_env.as_deref(), lookup)?;
+        }
+        #[cfg(feature = "stellar")]
+        Network::Stellar(net) => {
+            let _ = resolve_optional_rpc(&net.chain_id, net.rpc.as_ref(), lookup)?;
+        }
+        #[cfg(feature = "concordium")]
+        Network::Concordium(net) => {
+            let _ = resolve_optional_grpc(&net.chain_id, net.grpc.as_ref(), lookup)?;
         }
     }
     Ok(())

--- a/crates/facilitator/src/config/network.rs
+++ b/crates/facilitator/src/config/network.rs
@@ -1,5 +1,8 @@
 //! Per-network tables keyed by CAIP-2 id.
 
+#[cfg(feature = "concordium")]
+use std::time::Duration;
+
 use r402_protocol::{AuthCaptureScheme, BatchSettlementScheme, ChainId, ExactScheme, UptoScheme};
 use serde::Deserialize;
 use url::Url;
@@ -18,6 +21,10 @@ const DEFAULT_SVM_CU_LIMIT: u32 = 200_000;
 #[cfg(feature = "xrpl")]
 const XRPL_HOT_WALLET_KEYS: [&str; 5] =
     ["signers", "fee_payer", "signer", "relayers", "fee_payers"];
+
+/// Keeta has no RPC; these keys are operator mistakes.
+#[cfg(feature = "keeta")]
+const KEETA_RPC_KEYS: [&str; 2] = ["rpc", "rpc_env"];
 
 /// One configured network after schema validation.
 #[derive(Debug, Clone)]
@@ -42,6 +49,21 @@ pub enum Network {
     /// Algorand network.
     #[cfg(feature = "avm")]
     Avm(AvmNetwork),
+    /// Aptos network.
+    #[cfg(feature = "aptos")]
+    Aptos(AptosNetwork),
+    /// Keeta network.
+    #[cfg(feature = "keeta")]
+    Keeta(KeetaNetwork),
+    /// TON / TVM network.
+    #[cfg(feature = "tvm")]
+    Tvm(TvmNetwork),
+    /// Stellar network.
+    #[cfg(feature = "stellar")]
+    Stellar(StellarNetwork),
+    /// Concordium network.
+    #[cfg(feature = "concordium")]
+    Concordium(ConcordiumNetwork),
 }
 
 impl Network {
@@ -59,6 +81,16 @@ impl Network {
             Self::Hedera(net) => &net.chain_id,
             #[cfg(feature = "avm")]
             Self::Avm(net) => &net.chain_id,
+            #[cfg(feature = "aptos")]
+            Self::Aptos(net) => &net.chain_id,
+            #[cfg(feature = "keeta")]
+            Self::Keeta(net) => &net.chain_id,
+            #[cfg(feature = "tvm")]
+            Self::Tvm(net) => &net.chain_id,
+            #[cfg(feature = "stellar")]
+            Self::Stellar(net) => &net.chain_id,
+            #[cfg(feature = "concordium")]
+            Self::Concordium(net) => &net.chain_id,
         }
     }
 
@@ -76,6 +108,16 @@ impl Network {
             Self::Hedera(net) => &net.schemes,
             #[cfg(feature = "avm")]
             Self::Avm(net) => &net.schemes,
+            #[cfg(feature = "aptos")]
+            Self::Aptos(net) => &net.schemes,
+            #[cfg(feature = "keeta")]
+            Self::Keeta(net) => &net.schemes,
+            #[cfg(feature = "tvm")]
+            Self::Tvm(net) => &net.schemes,
+            #[cfg(feature = "stellar")]
+            Self::Stellar(net) => &net.schemes,
+            #[cfg(feature = "concordium")]
+            Self::Concordium(net) => &net.schemes,
         }
     }
 
@@ -93,6 +135,16 @@ impl Network {
             Self::Hedera(net) => &net.fee_payer_signer_names,
             #[cfg(feature = "avm")]
             Self::Avm(net) => &net.signers,
+            #[cfg(feature = "aptos")]
+            Self::Aptos(net) => &net.fee_payers,
+            #[cfg(feature = "keeta")]
+            Self::Keeta(net) => std::slice::from_ref(&net.signer),
+            #[cfg(feature = "tvm")]
+            Self::Tvm(net) => std::slice::from_ref(&net.signer),
+            #[cfg(feature = "stellar")]
+            Self::Stellar(net) => &net.signer_names,
+            #[cfg(feature = "concordium")]
+            Self::Concordium(net) => &net.signer_names,
         }
     }
 }
@@ -229,6 +281,128 @@ pub struct AvmNetwork {
     pub schemes: Vec<String>,
     /// Confirmation wait rounds; `None` uses SDK default 10.
     pub wait_rounds: Option<u32>,
+}
+
+/// Parsed Aptos `[network."<caip2>"]`.
+#[cfg(feature = "aptos")]
+#[derive(Debug, Clone)]
+pub struct AptosNetwork {
+    /// CAIP-2 id (`aptos:1` / `aptos:2`).
+    pub chain_id: ChainId,
+    /// Optional RPC; `None` uses the SDK default fullnode.
+    pub rpc: Option<RpcConfig>,
+    /// Named `[signer.*]` fee-payer references.
+    pub fee_payers: Vec<String>,
+    /// Scheme names (`exact`).
+    pub schemes: Vec<String>,
+    /// Whether `/supported` advertises sponsorship (SDK default true).
+    pub sponsor_transactions: bool,
+}
+
+/// Parsed Keeta `[network."<caip2>"]`.
+#[cfg(feature = "keeta")]
+#[derive(Debug, Clone)]
+pub struct KeetaNetwork {
+    /// CAIP-2 id (`keeta:21378` / `keeta:1413829460`).
+    pub chain_id: ChainId,
+    /// Named `[signer.*]` 32-byte ed25519 seed.
+    pub signer: String,
+    /// Derivation indices for `KeetaFeePayer::from_ed25519_seed`.
+    pub indices: Vec<u32>,
+    /// Scheme names (`exact`).
+    pub schemes: Vec<String>,
+}
+
+/// Parsed TVM `[network."<caip2>"]`.
+#[cfg(feature = "tvm")]
+#[derive(Debug, Clone)]
+pub struct TvmNetwork {
+    /// CAIP-2 id (`tvm:-239` / `tvm:-3`).
+    pub chain_id: ChainId,
+    /// Optional Toncenter/TonAPI base URL; `None` uses the SDK default.
+    pub provider_base_url: Option<Url>,
+    /// Optional env var holding a REST API key (independent of the URL).
+    pub api_key_env: Option<String>,
+    /// Named `[signer.*]` Highload V3 key.
+    pub signer: String,
+    /// Scheme names (`exact`).
+    pub schemes: Vec<String>,
+    /// Highload subwallet id; `None` uses SDK `0x10ad`.
+    pub subwallet_id: Option<u32>,
+    /// Highload timeout seconds; `None` uses SDK `3600`.
+    pub timeout: Option<u32>,
+    /// Wallet workchain; `None` uses `0`.
+    pub workchain: Option<i32>,
+    /// Batcher idle flush interval; `None` uses the SDK default.
+    pub batch_flush_interval_seconds: Option<u64>,
+    /// Queue length that triggers a flush; `None` uses the SDK default.
+    pub batch_flush_size: Option<usize>,
+    /// Trace confirmation timeout; `None` uses the SDK default.
+    pub confirmation_timeout_seconds: Option<u64>,
+}
+
+/// Parsed Stellar `[network."<caip2>"]`.
+#[cfg(feature = "stellar")]
+#[derive(Debug, Clone)]
+pub struct StellarNetwork {
+    /// CAIP-2 id (`stellar:pubnet` / `stellar:testnet`).
+    pub chain_id: ChainId,
+    /// Optional RPC; `None` uses the SDK default on testnet. Pubnet requires one.
+    pub rpc: Option<RpcConfig>,
+    /// Named inner-transaction signers.
+    pub signers: Vec<String>,
+    /// Optional named fee-bump signer.
+    pub fee_bump: Option<String>,
+    /// Flattened `signers` plus `fee_bump` for `signer_names`.
+    pub signer_names: Vec<String>,
+    /// Scheme names (`exact`).
+    pub schemes: Vec<String>,
+    /// Optional Horizon base URL.
+    pub horizon_url: Option<Url>,
+    /// Settlement-fee ceiling in stroops; `None` uses the SDK default.
+    pub max_transaction_fee_stroops: Option<u32>,
+}
+
+/// Named Concordium account plus `[signer.*]` reference.
+#[cfg(feature = "concordium")]
+#[derive(Debug, Clone)]
+pub struct ConcordiumAccount {
+    /// `Base58Check` account address.
+    pub address: String,
+    /// Named `[signer.*]` id.
+    pub signer: String,
+}
+
+/// Literal gRPC endpoint or env var name.
+#[cfg(feature = "concordium")]
+#[derive(Debug, Clone)]
+pub enum GrpcConfig {
+    /// URI or `host:port` from TOML.
+    Literal(String),
+    /// Environment variable holding a URI or `host:port`.
+    Env(String),
+}
+
+/// Parsed Concordium `[network."<caip2>"]`.
+#[cfg(feature = "concordium")]
+#[derive(Debug, Clone)]
+pub struct ConcordiumNetwork {
+    /// CAIP-2 id (genesis-hash reference).
+    pub chain_id: ChainId,
+    /// Optional gRPC; `None` uses `default_grpc_https()`.
+    pub grpc: Option<GrpcConfig>,
+    /// Sponsor accounts.
+    pub signers: Vec<ConcordiumAccount>,
+    /// Flattened `signers[].signer` for `signer_names`.
+    pub signer_names: Vec<String>,
+    /// Scheme names (`exact`).
+    pub schemes: Vec<String>,
+    /// Whether settle waits for `ConcordiumBFT` finalization.
+    pub require_finalization: bool,
+    /// Finalization wait; `None` uses the SDK default.
+    pub finalization_timeout: Option<Duration>,
+    /// Spec Rule 7 expiry cap; `None` uses the SDK default.
+    pub max_expiry_offset_seconds: Option<u64>,
 }
 
 /// RPC source: literal endpoints or one env var.
@@ -396,6 +570,134 @@ struct RawAvmNetwork {
     wait_rounds: Option<u32>,
 }
 
+#[cfg(feature = "aptos")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAptosNetwork {
+    /// Literal RPC URL.
+    #[serde(default)]
+    rpc: Option<String>,
+    /// Env name for the RPC URL.
+    #[serde(default)]
+    rpc_env: Option<String>,
+    /// Named fee-payer signers.
+    fee_payers: Vec<String>,
+    /// Scheme names.
+    schemes: Vec<String>,
+    /// Sponsorship advertised on `/supported`.
+    #[serde(default)]
+    sponsor_transactions: Option<bool>,
+}
+
+#[cfg(feature = "keeta")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawKeetaNetwork {
+    /// Named `[signer.*]` seed.
+    signer: String,
+    /// Derivation indices.
+    indices: Vec<u32>,
+    /// Scheme names.
+    schemes: Vec<String>,
+}
+
+#[cfg(feature = "tvm")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawTvmNetwork {
+    /// Toncenter/TonAPI base URL override.
+    #[serde(default)]
+    provider_base_url: Option<String>,
+    /// Alias for `provider_base_url` (mutually exclusive).
+    #[serde(default)]
+    rpc: Option<String>,
+    /// Env name for a REST API key (not xor with the URL).
+    #[serde(default)]
+    api_key_env: Option<String>,
+    /// Named Highload V3 signer.
+    signer: String,
+    /// Scheme names.
+    schemes: Vec<String>,
+    /// Highload subwallet id.
+    #[serde(default)]
+    subwallet_id: Option<u32>,
+    /// Highload timeout seconds.
+    #[serde(default)]
+    timeout: Option<u32>,
+    /// Wallet workchain.
+    #[serde(default)]
+    workchain: Option<i32>,
+    /// Batcher idle flush interval.
+    #[serde(default)]
+    batch_flush_interval_seconds: Option<u64>,
+    /// Queue length that triggers a flush.
+    #[serde(default)]
+    batch_flush_size: Option<usize>,
+    /// Trace confirmation timeout.
+    #[serde(default)]
+    confirmation_timeout_seconds: Option<u64>,
+}
+
+#[cfg(feature = "stellar")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawStellarNetwork {
+    /// Literal RPC URL.
+    #[serde(default)]
+    rpc: Option<String>,
+    /// Env name for the RPC URL.
+    #[serde(default)]
+    rpc_env: Option<String>,
+    /// Named inner-transaction signers.
+    signers: Vec<String>,
+    /// Optional named fee-bump signer.
+    #[serde(default)]
+    fee_bump: Option<String>,
+    /// Scheme names.
+    schemes: Vec<String>,
+    /// Optional Horizon URL.
+    #[serde(default)]
+    horizon_url: Option<String>,
+    /// Settlement-fee ceiling in stroops.
+    #[serde(default)]
+    max_transaction_fee_stroops: Option<u32>,
+}
+
+#[cfg(feature = "concordium")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConcordiumNetwork {
+    /// Literal gRPC URI or `host:port`.
+    #[serde(default)]
+    grpc: Option<String>,
+    /// Env name for the gRPC endpoint.
+    #[serde(default)]
+    grpc_env: Option<String>,
+    /// Sponsor `{ address, signer }`.
+    signers: Vec<RawConcordiumAccount>,
+    /// Scheme names.
+    schemes: Vec<String>,
+    /// Wait for finalization (default true).
+    #[serde(default)]
+    require_finalization: Option<bool>,
+    /// Finalization wait timeout.
+    #[serde(default, with = "humantime_serde::option")]
+    finalization_timeout: Option<Duration>,
+    /// Spec Rule 7 expiry cap.
+    #[serde(default)]
+    max_expiry_offset_seconds: Option<u64>,
+}
+
+#[cfg(feature = "concordium")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConcordiumAccount {
+    /// `Base58Check` account address.
+    address: String,
+    /// Named `[signer.*]` id.
+    signer: String,
+}
+
 #[cfg(any(feature = "near", feature = "hedera"))]
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -423,6 +725,16 @@ pub(crate) fn parse_network(
         HostableFamily::Hedera => parse_hedera(chain_id, value).map(Network::Hedera),
         #[cfg(feature = "avm")]
         HostableFamily::Avm => parse_avm(chain_id, value).map(Network::Avm),
+        #[cfg(feature = "aptos")]
+        HostableFamily::Aptos => parse_aptos(chain_id, value).map(Network::Aptos),
+        #[cfg(feature = "keeta")]
+        HostableFamily::Keeta => parse_keeta(chain_id, value).map(Network::Keeta),
+        #[cfg(feature = "tvm")]
+        HostableFamily::Tvm => parse_tvm(chain_id, value).map(Network::Tvm),
+        #[cfg(feature = "stellar")]
+        HostableFamily::Stellar => parse_stellar(chain_id, value).map(Network::Stellar),
+        #[cfg(feature = "concordium")]
+        HostableFamily::Concordium => parse_concordium(chain_id, value).map(Network::Concordium),
     }
 }
 
@@ -575,6 +887,143 @@ fn parse_avm(chain_id: &ChainId, value: toml::Value) -> Result<AvmNetwork, Error
     })
 }
 
+#[cfg(feature = "aptos")]
+fn parse_aptos(chain_id: &ChainId, value: toml::Value) -> Result<AptosNetwork, Error> {
+    let raw: RawAptosNetwork = value.try_into().map_err(|err: toml::de::Error| {
+        Error::config(format!("invalid [network.\"{chain_id}\"]: {err}"))
+    })?;
+    r402_aptos::chain::AptosChainReference::try_from(chain_id.clone())
+        .map_err(|err| Error::config_with(format!("invalid Aptos chain id '{chain_id}'"), err))?;
+    let rpc = optional_rpc(chain_id, raw.rpc, raw.rpc_env)?;
+    let schemes = require_schemes(chain_id, HostableFamily::Aptos, raw.schemes)?;
+    if raw.fee_payers.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `fee_payers` must not be empty"
+        )));
+    }
+    Ok(AptosNetwork {
+        chain_id: chain_id.clone(),
+        rpc,
+        fee_payers: raw.fee_payers,
+        schemes,
+        sponsor_transactions: raw.sponsor_transactions.unwrap_or(true),
+    })
+}
+
+#[cfg(feature = "keeta")]
+fn parse_keeta(chain_id: &ChainId, value: toml::Value) -> Result<KeetaNetwork, Error> {
+    reject_keeta_rpc(chain_id, &value)?;
+    let raw: RawKeetaNetwork = value.try_into().map_err(|err: toml::de::Error| {
+        Error::config(format!("invalid [network.\"{chain_id}\"]: {err}"))
+    })?;
+    r402_keeta::chain::KeetaChainReference::try_from(chain_id.clone())
+        .map_err(|err| Error::config_with(format!("invalid Keeta chain id '{chain_id}'"), err))?;
+    let schemes = require_schemes(chain_id, HostableFamily::Keeta, raw.schemes)?;
+    if raw.signer.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `signer` must not be empty"
+        )));
+    }
+    if raw.indices.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `indices` must not be empty"
+        )));
+    }
+    Ok(KeetaNetwork {
+        chain_id: chain_id.clone(),
+        signer: raw.signer,
+        indices: raw.indices,
+        schemes,
+    })
+}
+
+#[cfg(feature = "tvm")]
+fn parse_tvm(chain_id: &ChainId, value: toml::Value) -> Result<TvmNetwork, Error> {
+    let raw: RawTvmNetwork = value.try_into().map_err(|err: toml::de::Error| {
+        Error::config(format!("invalid [network.\"{chain_id}\"]: {err}"))
+    })?;
+    r402_tvm::chain::TvmChainReference::try_from(chain_id.clone())
+        .map_err(|err| Error::config_with(format!("invalid TVM chain id '{chain_id}'"), err))?;
+    let provider_base_url = optional_tvm_url(chain_id, raw.provider_base_url, raw.rpc)?;
+    let schemes = require_schemes(chain_id, HostableFamily::Tvm, raw.schemes)?;
+    if raw.signer.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `signer` must not be empty"
+        )));
+    }
+    Ok(TvmNetwork {
+        chain_id: chain_id.clone(),
+        provider_base_url,
+        api_key_env: raw.api_key_env,
+        signer: raw.signer,
+        schemes,
+        subwallet_id: raw.subwallet_id,
+        timeout: raw.timeout,
+        workchain: raw.workchain,
+        batch_flush_interval_seconds: raw.batch_flush_interval_seconds,
+        batch_flush_size: raw.batch_flush_size,
+        confirmation_timeout_seconds: raw.confirmation_timeout_seconds,
+    })
+}
+
+#[cfg(feature = "stellar")]
+fn parse_stellar(chain_id: &ChainId, value: toml::Value) -> Result<StellarNetwork, Error> {
+    let raw: RawStellarNetwork = value.try_into().map_err(|err: toml::de::Error| {
+        Error::config(format!("invalid [network.\"{chain_id}\"]: {err}"))
+    })?;
+    let chain = r402_stellar::chain::StellarChainReference::try_from(chain_id.clone())
+        .map_err(|err| Error::config_with(format!("invalid Stellar chain id '{chain_id}'"), err))?;
+    let rpc = optional_rpc(chain_id, raw.rpc, raw.rpc_env)?;
+    if rpc.is_none() && chain.default_rpc_url().is_none() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] requires `rpc` or `rpc_env` (stellar pubnet has no SDK default)"
+        )));
+    }
+    let schemes = require_schemes(chain_id, HostableFamily::Stellar, raw.schemes)?;
+    if raw.signers.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `signers` must not be empty"
+        )));
+    }
+    let signer_names = stellar_signer_names(&raw.signers, raw.fee_bump.as_deref());
+    Ok(StellarNetwork {
+        chain_id: chain_id.clone(),
+        rpc,
+        signers: raw.signers,
+        fee_bump: raw.fee_bump,
+        signer_names,
+        schemes,
+        horizon_url: raw
+            .horizon_url
+            .map(|url| parse_http_url(&url))
+            .transpose()?,
+        max_transaction_fee_stroops: raw.max_transaction_fee_stroops,
+    })
+}
+
+#[cfg(feature = "concordium")]
+fn parse_concordium(chain_id: &ChainId, value: toml::Value) -> Result<ConcordiumNetwork, Error> {
+    let raw: RawConcordiumNetwork = value.try_into().map_err(|err: toml::de::Error| {
+        Error::config(format!("invalid [network.\"{chain_id}\"]: {err}"))
+    })?;
+    r402_concordium::chain::ConcordiumChainReference::try_from(chain_id.clone()).map_err(
+        |err| Error::config_with(format!("invalid Concordium chain id '{chain_id}'"), err),
+    )?;
+    let grpc = optional_grpc(chain_id, raw.grpc, raw.grpc_env)?;
+    let schemes = require_schemes(chain_id, HostableFamily::Concordium, raw.schemes)?;
+    let (signers, signer_names) = require_concordium_accounts(chain_id, raw.signers)?;
+    Ok(ConcordiumNetwork {
+        chain_id: chain_id.clone(),
+        grpc,
+        signers,
+        signer_names,
+        schemes,
+        require_finalization: raw.require_finalization.unwrap_or(true),
+        finalization_timeout: raw.finalization_timeout,
+        max_expiry_offset_seconds: raw.max_expiry_offset_seconds,
+    })
+}
+
 #[cfg(feature = "xrpl")]
 fn reject_xrpl_hot_wallet(chain_id: &ChainId, value: &toml::Value) -> Result<(), Error> {
     let Some(table) = value.as_table() else {
@@ -588,6 +1037,64 @@ fn reject_xrpl_hot_wallet(chain_id: &ChainId, value: &toml::Value) -> Result<(),
         }
     }
     Ok(())
+}
+
+#[cfg(feature = "keeta")]
+fn reject_keeta_rpc(chain_id: &ChainId, value: &toml::Value) -> Result<(), Error> {
+    let Some(table) = value.as_table() else {
+        return Ok(());
+    };
+    for key in KEETA_RPC_KEYS {
+        if table.contains_key(key) {
+            return Err(Error::config(format!(
+                "[network.\"{chain_id}\"] Keeta has no RPC; `{key}` is not valid"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "stellar")]
+fn stellar_signer_names(signers: &[String], fee_bump: Option<&str>) -> Vec<String> {
+    let mut names = signers.to_vec();
+    if let Some(bump) = fee_bump
+        && !names.iter().any(|name| name == bump)
+    {
+        names.push(bump.to_owned());
+    }
+    names
+}
+
+#[cfg(feature = "concordium")]
+fn require_concordium_accounts(
+    chain_id: &ChainId,
+    raw: Vec<RawConcordiumAccount>,
+) -> Result<(Vec<ConcordiumAccount>, Vec<String>), Error> {
+    if raw.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `signers` must not be empty"
+        )));
+    }
+    let mut accounts = Vec::with_capacity(raw.len());
+    let mut names = Vec::with_capacity(raw.len());
+    for item in raw {
+        if item.address.is_empty() {
+            return Err(Error::config(format!(
+                "[network.\"{chain_id}\"] `signers` entry `address` must not be empty"
+            )));
+        }
+        if item.signer.is_empty() {
+            return Err(Error::config(format!(
+                "[network.\"{chain_id}\"] `signers` entry `signer` must not be empty"
+            )));
+        }
+        names.push(item.signer.clone());
+        accounts.push(ConcordiumAccount {
+            address: item.address,
+            signer: item.signer,
+        });
+    }
+    Ok((accounts, names))
 }
 
 #[cfg(any(feature = "near", feature = "hedera"))]
@@ -657,8 +1164,13 @@ fn require_rpc(
     }
 }
 
-/// NEAR / XRPL: at most one of `rpc` / `rpc_env`. Omit = SDK default.
-#[cfg(any(feature = "near", feature = "xrpl"))]
+/// NEAR / XRPL / Aptos / Stellar: at most one of `rpc` / `rpc_env`. Omit = SDK default.
+#[cfg(any(
+    feature = "near",
+    feature = "xrpl",
+    feature = "aptos",
+    feature = "stellar"
+))]
 fn optional_rpc(
     chain_id: &ChainId,
     rpc: Option<String>,
@@ -672,6 +1184,52 @@ fn optional_rpc(
         (Some(url), None) => Ok(Some(RpcConfig::Literal(single_rpc(&url)?))),
         (None, Some(env)) => Ok(Some(RpcConfig::Env(env))),
     }
+}
+
+/// TVM: at most one of `provider_base_url` / `rpc`. Omit = Toncenter default.
+#[cfg(feature = "tvm")]
+fn optional_tvm_url(
+    chain_id: &ChainId,
+    provider_base_url: Option<String>,
+    rpc: Option<String>,
+) -> Result<Option<Url>, Error> {
+    match (provider_base_url, rpc) {
+        (Some(_), Some(_)) => Err(Error::config(format!(
+            "[network.\"{chain_id}\"] accepts at most one of `provider_base_url` or `rpc`"
+        ))),
+        (None, None) => Ok(None),
+        (Some(url), None) | (None, Some(url)) => Ok(Some(parse_http_url(&url)?)),
+    }
+}
+
+/// Concordium: at most one of `grpc` / `grpc_env`. Omit = `default_grpc_https()`.
+#[cfg(feature = "concordium")]
+fn optional_grpc(
+    chain_id: &ChainId,
+    grpc: Option<String>,
+    grpc_env: Option<String>,
+) -> Result<Option<GrpcConfig>, Error> {
+    match (grpc, grpc_env) {
+        (Some(_), Some(_)) => Err(Error::config(format!(
+            "[network.\"{chain_id}\"] accepts at most one of `grpc` or `grpc_env`"
+        ))),
+        (None, None) => Ok(None),
+        (Some(endpoint), None) => Ok(Some(GrpcConfig::Literal(require_grpc_endpoint(
+            chain_id, &endpoint,
+        )?))),
+        (None, Some(env)) => Ok(Some(GrpcConfig::Env(env))),
+    }
+}
+
+#[cfg(feature = "concordium")]
+fn require_grpc_endpoint(chain_id: &ChainId, raw: &str) -> Result<String, Error> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `grpc` must not be empty"
+        )));
+    }
+    Ok(trimmed.to_owned())
 }
 
 fn require_eip155_reference(chain_id: &ChainId) -> Result<(), Error> {
@@ -722,6 +1280,16 @@ const fn known_scheme_names(family: HostableFamily) -> &'static [&'static str] {
         HostableFamily::Hedera => &[ExactScheme::VALUE],
         #[cfg(feature = "avm")]
         HostableFamily::Avm => &[ExactScheme::VALUE],
+        #[cfg(feature = "aptos")]
+        HostableFamily::Aptos => &[ExactScheme::VALUE],
+        #[cfg(feature = "keeta")]
+        HostableFamily::Keeta => &[ExactScheme::VALUE],
+        #[cfg(feature = "tvm")]
+        HostableFamily::Tvm => &[ExactScheme::VALUE],
+        #[cfg(feature = "stellar")]
+        HostableFamily::Stellar => &[ExactScheme::VALUE],
+        #[cfg(feature = "concordium")]
+        HostableFamily::Concordium => &[ExactScheme::VALUE],
     }
 }
 
@@ -807,7 +1375,12 @@ pub(crate) fn resolve_rpc(
 }
 
 /// Look up an optional env-backed RPC. `None` stays the SDK default.
-#[cfg(any(feature = "near", feature = "xrpl"))]
+#[cfg(any(
+    feature = "near",
+    feature = "xrpl",
+    feature = "aptos",
+    feature = "stellar"
+))]
 pub(crate) fn resolve_optional_rpc(
     chain_id: &ChainId,
     rpc: Option<&RpcConfig>,
@@ -821,6 +1394,51 @@ pub(crate) fn resolve_optional_rpc(
         .first()
         .ok_or_else(|| Error::config(format!("[network.\"{chain_id}\"] has no RPC URL")))?;
     Ok(Some(url.url.as_str().to_owned()))
+}
+
+/// Look up `api_key_env` when set.
+#[cfg(feature = "tvm")]
+pub(crate) fn resolve_api_key(
+    chain_id: &ChainId,
+    api_key_env: Option<&str>,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<Option<String>, Error> {
+    let Some(env) = api_key_env else {
+        return Ok(None);
+    };
+    let raw = lookup(env).ok_or_else(|| {
+        Error::config(format!(
+            "env var '{env}' not found for [network.\"{chain_id}\"] api_key_env"
+        ))
+    })?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(Error::config(format!(
+            "env var '{env}' is empty for [network.\"{chain_id}\"] api_key_env"
+        )));
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
+/// Look up optional Concordium gRPC. `None` stays `default_grpc_https()`.
+#[cfg(feature = "concordium")]
+pub(crate) fn resolve_optional_grpc(
+    chain_id: &ChainId,
+    grpc: Option<&GrpcConfig>,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<Option<String>, Error> {
+    match grpc {
+        None => Ok(None),
+        Some(GrpcConfig::Literal(endpoint)) => Ok(Some(endpoint.clone())),
+        Some(GrpcConfig::Env(env)) => {
+            let raw = lookup(env).ok_or_else(|| {
+                Error::config(format!(
+                    "env var '{env}' not found for [network.\"{chain_id}\"] grpc_env"
+                ))
+            })?;
+            Ok(Some(require_grpc_endpoint(chain_id, &raw)?))
+        }
+    }
 }
 
 /// Look up `algod_token_env` when set.

--- a/crates/facilitator/src/lib.rs
+++ b/crates/facilitator/src/lib.rs
@@ -22,12 +22,22 @@ use std::process::ExitCode;
 use clap::Parser;
 use cli::{Cli, Commands};
 pub use compose::{FacilitatorMap, build};
+#[cfg(feature = "aptos")]
+pub use config::AptosNetwork;
 #[cfg(feature = "avm")]
 pub use config::AvmNetwork;
+#[cfg(feature = "concordium")]
+pub use config::ConcordiumAccount;
+#[cfg(feature = "keeta")]
+pub use config::KeetaNetwork;
 #[cfg(any(feature = "near", feature = "hedera"))]
 pub use config::NamedAccount;
 #[cfg(feature = "near")]
 pub use config::NearNetwork;
+#[cfg(feature = "stellar")]
+pub use config::StellarNetwork;
+#[cfg(feature = "tvm")]
+pub use config::TvmNetwork;
 #[cfg(feature = "xrpl")]
 pub use config::XrplNetwork;
 pub use config::{
@@ -35,6 +45,8 @@ pub use config::{
     LogFormat, Network, RpcConfig, RpcEndpoint, SchemeTables, SvmExactConfig, SvmNetwork,
     SvmSchemeConfig, SvmUptoConfig, load_config, parse_config_toml,
 };
+#[cfg(feature = "concordium")]
+pub use config::{ConcordiumNetwork, GrpcConfig};
 #[cfg(feature = "hedera")]
 pub use config::{HederaAliasPolicy, HederaNetwork};
 pub use error::Error;

--- a/crates/facilitator/tests/compose_families.rs
+++ b/crates/facilitator/tests/compose_families.rs
@@ -1,4 +1,5 @@
-//! Compose: NEAR / XRPL / Hedera / AVM exact construction.
+//! Compose: remaining exact families (near/xrpl/hedera/avm + aptos/keeta/tvm/stellar).
+//! Concordium `connect` dials gRPC — parse + signer error mapping only.
 
 #![allow(
     unused_crate_dependencies,
@@ -20,17 +21,26 @@
     feature = "near",
     feature = "xrpl",
     feature = "hedera",
-    feature = "avm"
+    feature = "avm",
+    feature = "aptos",
+    feature = "keeta",
+    feature = "tvm",
+    feature = "stellar",
+    feature = "concordium"
 ))]
 use facilitator::{build, parse_config_toml};
 #[cfg(any(
     feature = "near",
     feature = "xrpl",
     feature = "hedera",
-    feature = "avm"
+    feature = "avm",
+    feature = "aptos",
+    feature = "keeta",
+    feature = "tvm",
+    feature = "stellar"
 ))]
 use r402_facilitator::Facilitator;
-#[cfg(any(feature = "near", feature = "hedera"))]
+#[cfg(any(feature = "near", feature = "hedera", feature = "aptos"))]
 use r402_protocol::payment::SupportedResponse;
 
 /// Dummy HTTP URL: `Provider::new` does not dial.
@@ -38,7 +48,10 @@ use r402_protocol::payment::SupportedResponse;
     feature = "near",
     feature = "xrpl",
     feature = "hedera",
-    feature = "avm"
+    feature = "avm",
+    feature = "aptos",
+    feature = "tvm",
+    feature = "stellar"
 ))]
 const DUMMY_RPC: &str = "http://127.0.0.1:1";
 
@@ -55,16 +68,41 @@ const HEDERA_KEY: &str = "302e020100300506032b65700422042098aa82d6125b5efa04bf83
 const HEDERA_ACCOUNT: &str = "0.0.5001";
 
 /// 32-byte ed25519 seed `[2u8; 32]` as standard base64.
-#[cfg(feature = "avm")]
+#[cfg(any(feature = "avm", feature = "keeta"))]
 const AVM_KEY: &str = "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=";
 #[cfg(feature = "avm")]
 const AVM_TESTNET: &str = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe";
+
+/// 32-byte ed25519 private key as hex (`[2u8; 32]`).
+#[cfg(feature = "aptos")]
+const APTOS_KEY: &str = "0202020202020202020202020202020202020202020202020202020202020202";
+
+/// 32-byte Highload seed as hex (`[7u8; 32]`).
+#[cfg(feature = "tvm")]
+const TVM_KEY: &str = "0707070707070707070707070707070707070707070707070707070707070707";
+
+/// Oracle Stellar secret (`S…`).
+#[cfg(feature = "stellar")]
+const STELLAR_KEY: &str = "SCKB3ECHCPVM4HJPNCQWTQWJJ5XRL6UNKLTTCIH4B7TB22NKJ5GUFMIV";
+
+/// 32-byte Concordium seed as hex.
+#[cfg(feature = "concordium")]
+const CCD_KEY: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+#[cfg(feature = "concordium")]
+const CCD_ADDRESS: &str = "2xdTv8awN1BjgYEw8W1BVXVtiEwG2b29U8KoZQqJrDuEqddseE";
+#[cfg(feature = "concordium")]
+const CCD_TESTNET: &str = "ccd:4221332d34e1694168c2a0c0b3fd0f27";
 
 #[cfg(any(
     feature = "near",
     feature = "xrpl",
     feature = "hedera",
-    feature = "avm"
+    feature = "avm",
+    feature = "aptos",
+    feature = "keeta",
+    feature = "tvm",
+    feature = "stellar",
+    feature = "concordium"
 ))]
 fn lookup(key: &str) -> Option<String> {
     match key {
@@ -74,6 +112,16 @@ fn lookup(key: &str) -> Option<String> {
         "FACILITATOR_HEDERA_KEY" => Some(HEDERA_KEY.to_owned()),
         #[cfg(feature = "avm")]
         "FACILITATOR_AVM_KEY" => Some(AVM_KEY.to_owned()),
+        #[cfg(feature = "keeta")]
+        "FACILITATOR_KEETA_KEY" => Some(AVM_KEY.to_owned()),
+        #[cfg(feature = "aptos")]
+        "FACILITATOR_APTOS_KEY" => Some(APTOS_KEY.to_owned()),
+        #[cfg(feature = "tvm")]
+        "FACILITATOR_TVM_KEY" => Some(TVM_KEY.to_owned()),
+        #[cfg(feature = "stellar")]
+        "FACILITATOR_STELLAR_KEY" => Some(STELLAR_KEY.to_owned()),
+        #[cfg(feature = "concordium")]
+        "FACILITATOR_CCD_KEY" => Some(CCD_KEY.to_owned()),
         _ => None,
     }
 }
@@ -200,6 +248,144 @@ async fn avm_invalid_key_is_startup_error() {
     );
 }
 
+#[cfg(feature = "aptos")]
+#[tokio::test]
+async fn aptos_exact_constructs() {
+    let cfg = parse_config_toml(&aptos_doc()).expect("parse");
+    let map = build(&cfg, &lookup).await.expect("construct");
+    let supported = Facilitator::supported(&map).await.expect("supported");
+    assert_exact_kind_at(&supported, 0, "aptos:1");
+    assert!(
+        supported.signers.contains_key("aptos:*"),
+        "aptos:* signer key"
+    );
+}
+
+#[cfg(feature = "aptos")]
+#[tokio::test]
+async fn aptos_invalid_key_is_startup_error() {
+    let cfg = parse_config_toml(&aptos_doc()).expect("parse");
+    let err = build(&cfg, &|key| {
+        (key == "FACILITATOR_APTOS_KEY").then(|| "not-an-aptos-key".to_owned())
+    })
+    .await
+    .expect_err("bad key");
+    assert!(
+        err.to_string()
+            .contains("signer 'aptos_hot' is not a valid Aptos private key"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "keeta")]
+#[tokio::test]
+async fn keeta_exact_constructs() {
+    let cfg = parse_config_toml(&keeta_doc()).expect("parse");
+    let map = build(&cfg, &lookup).await.expect("construct");
+    let supported = Facilitator::supported(&map).await.expect("supported");
+    assert_eq!(supported.kinds.len(), 1, "one kind");
+    let kind = &supported.kinds[0];
+    assert_eq!(kind.scheme.as_str(), "exact", "scheme");
+    assert_eq!(kind.network.as_str(), "keeta:1413829460", "network");
+    assert!(
+        supported.signers.contains_key("keeta:*"),
+        "keeta:* signer key"
+    );
+}
+
+#[cfg(feature = "keeta")]
+#[tokio::test]
+async fn keeta_invalid_key_is_startup_error() {
+    let cfg = parse_config_toml(&keeta_doc()).expect("parse");
+    let err = build(&cfg, &|key| {
+        (key == "FACILITATOR_KEETA_KEY").then(|| "not-base64".to_owned())
+    })
+    .await
+    .expect_err("bad key");
+    assert!(
+        err.to_string()
+            .contains("signer 'keeta_hot' is not a valid Keeta base64 seed"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "tvm")]
+#[tokio::test]
+async fn tvm_exact_constructs() {
+    let cfg = parse_config_toml(&tvm_doc()).expect("parse");
+    let map = build(&cfg, &lookup).await.expect("construct");
+    let supported = Facilitator::supported(&map).await.expect("supported");
+    assert_eq!(supported.kinds.len(), 1, "one kind");
+    let kind = &supported.kinds[0];
+    assert_eq!(kind.scheme.as_str(), "exact", "scheme");
+    assert_eq!(kind.network.as_str(), "tvm:-3", "network");
+    assert!(supported.signers.contains_key("tvm:*"), "tvm:* signer key");
+}
+
+#[cfg(feature = "tvm")]
+#[tokio::test]
+async fn tvm_invalid_key_is_startup_error() {
+    let cfg = parse_config_toml(&tvm_doc()).expect("parse");
+    let err = build(&cfg, &|key| {
+        (key == "FACILITATOR_TVM_KEY").then(|| "not-a-tvm-key".to_owned())
+    })
+    .await
+    .expect_err("bad key");
+    assert!(
+        err.to_string()
+            .contains("signer 'tvm_hot' is not a valid TVM Highload V3 private key"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "stellar")]
+#[tokio::test]
+async fn stellar_exact_constructs() {
+    let cfg = parse_config_toml(&stellar_doc()).expect("parse");
+    let map = build(&cfg, &lookup).await.expect("construct");
+    let supported = Facilitator::supported(&map).await.expect("supported");
+    assert_eq!(supported.kinds.len(), 1, "one kind");
+    let kind = &supported.kinds[0];
+    assert_eq!(kind.scheme.as_str(), "exact", "scheme");
+    assert_eq!(kind.network.as_str(), "stellar:testnet", "network");
+    assert!(
+        supported.signers.contains_key("stellar:*"),
+        "stellar:* signer key"
+    );
+}
+
+#[cfg(feature = "stellar")]
+#[tokio::test]
+async fn stellar_invalid_key_is_startup_error() {
+    let cfg = parse_config_toml(&stellar_doc()).expect("parse");
+    let err = build(&cfg, &|key| {
+        (key == "FACILITATOR_STELLAR_KEY").then(|| "not-a-stellar-key".to_owned())
+    })
+    .await
+    .expect_err("bad key");
+    assert!(
+        err.to_string()
+            .contains("signer 'stellar_hot' is not a valid Stellar secret key"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "concordium")]
+#[tokio::test]
+async fn concordium_invalid_key_is_startup_error() {
+    let cfg = parse_config_toml(&ccd_doc()).expect("parse");
+    let err = build(&cfg, &|key| {
+        (key == "FACILITATOR_CCD_KEY").then(|| "not-hex".to_owned())
+    })
+    .await
+    .expect_err("bad key");
+    assert!(
+        err.to_string()
+            .contains("signer 'ccd_hot' is not a valid Concordium address+seed"),
+        "got {err}"
+    );
+}
+
 #[cfg(feature = "near")]
 fn near_doc() -> String {
     format!(
@@ -275,7 +461,105 @@ algod_url = "{DUMMY_RPC}"
     )
 }
 
-#[cfg(any(feature = "near", feature = "hedera"))]
+#[cfg(feature = "aptos")]
+fn aptos_doc() -> String {
+    format!(
+        r#"
+[http]
+listen = "127.0.0.1:8080"
+settle_timeout = "30s"
+
+[signer.aptos_hot]
+source = "env"
+env = "FACILITATOR_APTOS_KEY"
+
+[network."aptos:1"]
+rpc = "{DUMMY_RPC}"
+fee_payers = ["aptos_hot"]
+schemes = ["exact"]
+"#
+    )
+}
+
+#[cfg(feature = "keeta")]
+fn keeta_doc() -> String {
+    r#"
+[http]
+listen = "127.0.0.1:8080"
+settle_timeout = "30s"
+
+[signer.keeta_hot]
+source = "env"
+env = "FACILITATOR_KEETA_KEY"
+
+[network."keeta:1413829460"]
+signer = "keeta_hot"
+indices = [0]
+schemes = ["exact"]
+"#
+    .to_owned()
+}
+
+#[cfg(feature = "tvm")]
+fn tvm_doc() -> String {
+    format!(
+        r#"
+[http]
+listen = "127.0.0.1:8080"
+settle_timeout = "30s"
+
+[signer.tvm_hot]
+source = "env"
+env = "FACILITATOR_TVM_KEY"
+
+[network."tvm:-3"]
+rpc = "{DUMMY_RPC}"
+signer = "tvm_hot"
+schemes = ["exact"]
+"#
+    )
+}
+
+#[cfg(feature = "stellar")]
+fn stellar_doc() -> String {
+    format!(
+        r#"
+[http]
+listen = "127.0.0.1:8080"
+settle_timeout = "30s"
+
+[signer.stellar_hot]
+source = "env"
+env = "FACILITATOR_STELLAR_KEY"
+
+[network."stellar:testnet"]
+rpc = "{DUMMY_RPC}"
+signers = ["stellar_hot"]
+schemes = ["exact"]
+"#
+    )
+}
+
+#[cfg(feature = "concordium")]
+fn ccd_doc() -> String {
+    format!(
+        r#"
+[http]
+listen = "127.0.0.1:8080"
+settle_timeout = "30s"
+
+[signer.ccd_hot]
+source = "env"
+env = "FACILITATOR_CCD_KEY"
+
+[network."{CCD_TESTNET}"]
+signers = [{{ address = "{CCD_ADDRESS}", signer = "ccd_hot" }}]
+schemes = ["exact"]
+"#
+    )
+}
+
+#[cfg(any(feature = "near", feature = "hedera", feature = "aptos"))]
 fn assert_exact_kind_at(supported: &SupportedResponse, index: usize, network: &str) {
     let kind = &supported.kinds[index];
     assert_eq!(kind.x402_version, 2, "V2");

--- a/crates/facilitator/tests/config.rs
+++ b/crates/facilitator/tests/config.rs
@@ -537,6 +537,7 @@ schemes = ["exact"]
     assert!(avm.algod_token_env.is_none(), "omit token");
 }
 
+#[cfg(not(feature = "aptos"))]
 #[test]
 fn compiled_out_aptos_names_feature() {
     let raw = r#"
@@ -553,6 +554,373 @@ schemes = ["exact"]
         "got {err}"
     );
     assert!(err.to_string().contains("--features aptos"), "got {err}");
+}
+
+#[cfg(feature = "aptos")]
+#[test]
+fn aptos_optional_rpc_omit_ok() {
+    let raw = r#"
+[signer.aptos_hot]
+source = "env"
+env = "APTOS_KEY"
+[network."aptos:1"]
+fee_payers = ["aptos_hot"]
+schemes = ["exact"]
+"#;
+    let cfg = parse_config_toml(raw).expect("omit rpc");
+    let aptos = cfg.networks.iter().find_map(|net| {
+        if let Network::Aptos(aptos) = net {
+            Some(aptos)
+        } else {
+            None
+        }
+    });
+    let aptos = aptos.expect("aptos network");
+    assert!(aptos.rpc.is_none(), "omit = SDK default");
+    assert!(aptos.sponsor_transactions, "provider default true");
+    assert_eq!(
+        aptos.fee_payers,
+        ["aptos_hot".to_owned()],
+        "fee payer names"
+    );
+}
+
+#[cfg(feature = "aptos")]
+#[test]
+fn aptos_rpc_and_rpc_env_are_exclusive() {
+    let raw = r#"
+[signer.aptos_hot]
+source = "env"
+env = "APTOS_KEY"
+[network."aptos:1"]
+rpc = "http://127.0.0.1:1"
+rpc_env = "APTOS_RPC"
+fee_payers = ["aptos_hot"]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("at most one of `rpc` or `rpc_env`"),
+        "got {err}"
+    );
+}
+
+#[cfg(not(feature = "keeta"))]
+#[test]
+fn compiled_out_keeta_names_feature() {
+    let raw = r#"
+[signer.keeta_hot]
+source = "env"
+env = "KEETA_KEY"
+[network."keeta:1413829460"]
+signer = "keeta_hot"
+indices = [0]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string().contains("compiled-out family 'keeta'"),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("--features keeta"), "got {err}");
+}
+
+#[cfg(feature = "keeta")]
+#[test]
+fn keeta_parses_signer_and_indices() {
+    let raw = r#"
+[signer.keeta_hot]
+source = "env"
+env = "KEETA_KEY"
+[network."keeta:1413829460"]
+signer = "keeta_hot"
+indices = [0, 1]
+schemes = ["exact"]
+"#;
+    let cfg = parse_config_toml(raw).expect("keeta");
+    let keeta = cfg.networks.iter().find_map(|net| {
+        if let Network::Keeta(keeta) = net {
+            Some(keeta)
+        } else {
+            None
+        }
+    });
+    let keeta = keeta.expect("keeta network");
+    assert_eq!(keeta.signer, "keeta_hot", "named signer");
+    assert_eq!(keeta.indices, [0, 1], "derivation indices");
+}
+
+#[cfg(feature = "keeta")]
+#[test]
+fn keeta_rejects_rpc() {
+    let raw = r#"
+[signer.keeta_hot]
+source = "env"
+env = "KEETA_KEY"
+[network."keeta:1413829460"]
+rpc = "http://127.0.0.1:1"
+signer = "keeta_hot"
+indices = [0]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(err.to_string().contains("Keeta has no RPC"), "got {err}");
+    assert!(err.to_string().contains("`rpc`"), "got {err}");
+}
+
+#[cfg(feature = "keeta")]
+#[test]
+fn keeta_rejects_rpc_env() {
+    let raw = r#"
+[signer.keeta_hot]
+source = "env"
+env = "KEETA_KEY"
+[network."keeta:1413829460"]
+rpc_env = "KEETA_RPC"
+signer = "keeta_hot"
+indices = [0]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(err.to_string().contains("Keeta has no RPC"), "got {err}");
+    assert!(err.to_string().contains("`rpc_env`"), "got {err}");
+}
+
+#[cfg(not(feature = "tvm"))]
+#[test]
+fn compiled_out_tvm_names_feature() {
+    let raw = r#"
+[signer.tvm_hot]
+source = "env"
+env = "TVM_KEY"
+[network."tvm:-3"]
+signer = "tvm_hot"
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string().contains("compiled-out family 'tvm'"),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("--features tvm"), "got {err}");
+}
+
+#[cfg(feature = "tvm")]
+#[test]
+fn tvm_optional_url_omit_ok() {
+    let raw = r#"
+[signer.tvm_hot]
+source = "env"
+env = "TVM_KEY"
+[network."tvm:-3"]
+signer = "tvm_hot"
+schemes = ["exact"]
+"#;
+    let cfg = parse_config_toml(raw).expect("omit url");
+    let tvm = cfg.networks.iter().find_map(|net| {
+        if let Network::Tvm(tvm) = net {
+            Some(tvm)
+        } else {
+            None
+        }
+    });
+    let tvm = tvm.expect("tvm network");
+    assert!(tvm.provider_base_url.is_none(), "omit = Toncenter default");
+    assert_eq!(tvm.signer, "tvm_hot", "named signer");
+}
+
+#[cfg(feature = "tvm")]
+#[test]
+fn tvm_provider_base_url_and_rpc_are_exclusive() {
+    let raw = r#"
+[signer.tvm_hot]
+source = "env"
+env = "TVM_KEY"
+[network."tvm:-3"]
+provider_base_url = "http://127.0.0.1:1"
+rpc = "http://127.0.0.1:2"
+signer = "tvm_hot"
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("at most one of `provider_base_url` or `rpc`"),
+        "got {err}"
+    );
+}
+
+#[cfg(not(feature = "stellar"))]
+#[test]
+fn compiled_out_stellar_names_feature() {
+    let raw = r#"
+[signer.stellar_hot]
+source = "env"
+env = "STELLAR_KEY"
+[network."stellar:testnet"]
+signers = ["stellar_hot"]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string().contains("compiled-out family 'stellar'"),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("--features stellar"), "got {err}");
+}
+
+#[cfg(feature = "stellar")]
+#[test]
+fn stellar_testnet_optional_rpc_omit_ok() {
+    let raw = r#"
+[signer.stellar_hot]
+source = "env"
+env = "STELLAR_KEY"
+[network."stellar:testnet"]
+signers = ["stellar_hot"]
+schemes = ["exact"]
+"#;
+    let cfg = parse_config_toml(raw).expect("omit rpc");
+    let stellar = cfg.networks.iter().find_map(|net| {
+        if let Network::Stellar(stellar) = net {
+            Some(stellar)
+        } else {
+            None
+        }
+    });
+    let stellar = stellar.expect("stellar network");
+    assert!(stellar.rpc.is_none(), "omit = SDK default on testnet");
+}
+
+#[cfg(feature = "stellar")]
+#[test]
+fn stellar_pubnet_requires_rpc() {
+    let raw = r#"
+[signer.stellar_hot]
+source = "env"
+env = "STELLAR_KEY"
+[network."stellar:pubnet"]
+signers = ["stellar_hot"]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string().contains("requires `rpc` or `rpc_env`"),
+        "got {err}"
+    );
+    assert!(err.to_string().contains("pubnet"), "got {err}");
+}
+
+#[cfg(feature = "stellar")]
+#[test]
+fn stellar_rpc_and_rpc_env_are_exclusive() {
+    let raw = r#"
+[signer.stellar_hot]
+source = "env"
+env = "STELLAR_KEY"
+[network."stellar:testnet"]
+rpc = "http://127.0.0.1:1"
+rpc_env = "STELLAR_RPC"
+signers = ["stellar_hot"]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("at most one of `rpc` or `rpc_env`"),
+        "got {err}"
+    );
+}
+
+#[cfg(not(feature = "concordium"))]
+#[test]
+fn compiled_out_ccd_names_feature() {
+    let raw = r#"
+[signer.ccd_hot]
+source = "env"
+env = "CCD_KEY"
+[network."ccd:4221332d34e1694168c2a0c0b3fd0f27"]
+signers = [{ address = "2xdTv8awN1BjgYEw8W1BVXVtiEwG2b29U8KoZQqJrDuEqddseE", signer = "ccd_hot" }]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string().contains("compiled-out family 'ccd'"),
+        "got {err}"
+    );
+    assert!(
+        err.to_string().contains("--features concordium"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "concordium")]
+#[test]
+fn ccd_optional_grpc_omit_ok() {
+    let raw = r#"
+[signer.ccd_hot]
+source = "env"
+env = "CCD_KEY"
+[network."ccd:4221332d34e1694168c2a0c0b3fd0f27"]
+signers = [{ address = "2xdTv8awN1BjgYEw8W1BVXVtiEwG2b29U8KoZQqJrDuEqddseE", signer = "ccd_hot" }]
+schemes = ["exact"]
+"#;
+    let cfg = parse_config_toml(raw).expect("omit grpc");
+    let ccd = cfg.networks.iter().find_map(|net| {
+        if let Network::Concordium(ccd) = net {
+            Some(ccd)
+        } else {
+            None
+        }
+    });
+    let ccd = ccd.expect("ccd network");
+    assert!(ccd.grpc.is_none(), "omit = default_grpc_https");
+    assert_eq!(ccd.signer_names, ["ccd_hot".to_owned()], "flattened signer");
+    assert_eq!(
+        ccd.signers[0].address, "2xdTv8awN1BjgYEw8W1BVXVtiEwG2b29U8KoZQqJrDuEqddseE",
+        "address required"
+    );
+}
+
+#[cfg(feature = "concordium")]
+#[test]
+fn ccd_grpc_and_grpc_env_are_exclusive() {
+    let raw = r#"
+[signer.ccd_hot]
+source = "env"
+env = "CCD_KEY"
+[network."ccd:4221332d34e1694168c2a0c0b3fd0f27"]
+grpc = "http://127.0.0.1:1"
+grpc_env = "CCD_GRPC"
+signers = [{ address = "2xdTv8awN1BjgYEw8W1BVXVtiEwG2b29U8KoZQqJrDuEqddseE", signer = "ccd_hot" }]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("at most one of `grpc` or `grpc_env`"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "concordium")]
+#[test]
+fn ccd_requires_address_and_signer() {
+    let raw = r#"
+[signer.ccd_hot]
+source = "env"
+env = "CCD_KEY"
+[network."ccd:4221332d34e1694168c2a0c0b3fd0f27"]
+signers = [{ signer = "ccd_hot" }]
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("invalid [network.\"ccd:4221332d34e1694168c2a0c0b3fd0f27\"]"),
+        "got {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Host the remaining on-chain exact families behind Cargo features, using
r402 0.19.1 constructors. Aptos/TVM/Stellar/Concordium accept at most one
RPC or gRPC override (omit = SDK default; Stellar pubnet requires one).
Keeta takes signer+indices with no RPC and shares the process settlement
cache via with_settlement_cache(provider, queue, cache). TVM maps
snake_case TOML knobs onto TvmExactFacilitatorConfig. Concordium connect
dials gRPC; CI tests parse and signer errors only.
