### PR TITLE
feat: compose experimental-tron exact (not in default image)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           test -f "$dest/crates/r402-avm/Cargo.toml"
           test -f "$dest/crates/r402-aptos/Cargo.toml"
           test -f "$dest/crates/r402-concordium/Cargo.toml"
+          test -f "$dest/crates/r402-tron/Cargo.toml"
 
       # hedera-proto (r402-hedera) runs prost-build. ubuntu-latest ships
       # neither protoc nor google/protobuf/*.proto (wrappers.proto).
@@ -116,7 +117,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy families
-        run: cargo clippy --workspace --all-targets --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium -- -D warnings
+        run: cargo clippy --workspace --all-targets --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium,experimental-tron -- -D warnings
 
       - name: Test families
-        run: cargo test --workspace --verbose --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium
+        run: cargo test --workspace --verbose --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium,experimental-tron

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,6 +3177,7 @@ dependencies = [
  "r402-protocol",
  "r402-stellar",
  "r402-svm",
+ "r402-tron",
  "r402-tvm",
  "r402-xrpl",
  "serde",
@@ -6769,6 +6770,29 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "r402-tron"
+version = "0.19.1"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "bs58 0.5.1",
+ "compact_str",
+ "r402-facilitator",
+ "r402-protocol",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "url",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Tron is `experimental-tron` and is not in the default image.
 | `telemetry` | ✓ | Reserved for OTLP |
 | `metrics` | ✓ | Enables `r402-facilitator/metrics` |
 | `near` / `xrpl` / `hedera` / `avm` / `aptos` / `keeta` / `tvm` / `stellar` / `concordium` | | Host `exact` when the feature is on |
-| `experimental-tron` | | Experimental; not in the default image |
+| `experimental-tron` | | Host `exact` when rebuilt with this feature; not in the default image |
 
 `casper:*` is always a remote-client startup error. There is no `extra-casper` feature.
 

--- a/config.example.full.toml
+++ b/config.example.full.toml
@@ -83,6 +83,7 @@ max_compute_unit_limit = 200000      # SolanaChainProvider::new; default 200_000
 
 # --- Other exact families (commented: not in the default image) ---
 # Rebuild with --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium.
+# Tron: --features experimental-tron (experimental; not in the default image).
 # Casper is never hosted.
 
 # [signer.near_relayer]
@@ -197,3 +198,17 @@ max_compute_unit_limit = 200000      # SolanaChainProvider::new; default 200_000
 # # require_finalization = true
 # # finalization_timeout = "60s"
 # # max_expiry_offset_seconds = 600
+
+# [signer.tron_hot]
+# source = "file"
+# path = "/run/secrets/tron.key"
+# encoding = "hex"                   # secp256k1
+#
+# [network."tron:0x2b6653dc"]        # mainnet; nile tron:0xcd8690dc
+# # rpc / rpc_env: exactly one. TronGrid base URL (required; no SDK default).
+# rpc = "https://api.trongrid.io"
+# signer = "tron_hot"
+# schemes = ["exact"]
+# # fee_limit = 100000000            # SUN; compose default 100_000_000
+# # confirmation_timeout = "30s"
+# # confirmation_poll_interval = "1s"

--- a/crates/facilitator/Cargo.toml
+++ b/crates/facilitator/Cargo.toml
@@ -35,7 +35,7 @@ keeta = ["dep:r402-keeta", "r402-keeta/facilitator", "dep:base64"]
 tvm = ["dep:r402-tvm", "r402-tvm/facilitator"]
 stellar = ["dep:r402-stellar", "r402-stellar/facilitator"]
 concordium = ["dep:r402-concordium", "r402-concordium/facilitator"]
-experimental-tron = []
+experimental-tron = ["dep:r402-tron", "r402-tron/facilitator", "dep:alloy-signer-local"]
 telemetry = [
     "r402-evm?/telemetry",
     "r402-svm?/telemetry",
@@ -48,6 +48,7 @@ telemetry = [
     "r402-tvm?/telemetry",
     "r402-stellar?/telemetry",
     "r402-concordium?/telemetry",
+    "r402-tron?/telemetry",
 ]
 metrics = ["dep:metrics", "dep:metrics-exporter-prometheus", "r402-facilitator/metrics"]
 
@@ -88,6 +89,7 @@ r402-keeta = { version = "0.19.1", path = "../../../r402/crates/r402-keeta", def
 r402-tvm = { version = "0.19.1", path = "../../../r402/crates/r402-tvm", default-features = false, optional = true }
 r402-stellar = { version = "0.19.1", path = "../../../r402/crates/r402-stellar", default-features = false, optional = true }
 r402-concordium = { version = "0.19.1", path = "../../../r402/crates/r402-concordium", default-features = false, optional = true }
+r402-tron = { version = "0.19.1", path = "../../../r402/crates/r402-tron", default-features = false, optional = true }
 solana-keypair = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/facilitator/src/compose/mod.rs
+++ b/crates/facilitator/src/compose/mod.rs
@@ -18,6 +18,8 @@ mod near;
 mod stellar;
 #[cfg(feature = "svm")]
 mod svm;
+#[cfg(feature = "experimental-tron")]
+mod tron;
 #[cfg(feature = "tvm")]
 mod tvm;
 #[cfg(feature = "xrpl")]
@@ -36,7 +38,8 @@ use compact_str::CompactString;
     feature = "keeta",
     feature = "tvm",
     feature = "stellar",
-    feature = "concordium"
+    feature = "concordium",
+    feature = "experimental-tron"
 ))]
 use r402_facilitator::SettlementCache;
 use r402_facilitator::{DynFacilitator, Facilitator};
@@ -143,8 +146,8 @@ impl Facilitator for FacilitatorMap {
 /// EVM exact/upto and SVM exact use `with_settlement_cache` as a constructor
 /// (never `try_new`) so they share the process
 /// [`r402_facilitator::SettlementCache`]. Hedera, AVM, Aptos, Keeta, TVM,
-/// Stellar, and Concordium exact share that cache too. NEAR and XRPL use
-/// private cache types (one per process). SVM upto uses `new`,
+/// Stellar, Concordium, and Tron exact share that cache too. NEAR and XRPL
+/// use private cache types (one per process). SVM upto uses `new`,
 /// `with_storage`, and `with_pending_store` (no settlement-cache constructor;
 /// r402 0.19.1 has no rent-cleanup manager). Auth-capture uses
 /// `try_new(provider)` only. Batch-settlement uses `with_store` with a
@@ -170,7 +173,8 @@ pub async fn build(
         feature = "keeta",
         feature = "tvm",
         feature = "stellar",
-        feature = "concordium"
+        feature = "concordium",
+        feature = "experimental-tron"
     ))]
     let cache = SettlementCache::new();
     #[cfg(any(feature = "evm", feature = "svm"))]
@@ -196,7 +200,8 @@ pub async fn build(
             feature = "keeta",
             feature = "tvm",
             feature = "stellar",
-            feature = "concordium"
+            feature = "concordium",
+            feature = "experimental-tron"
         ))
     ))]
     drop(cache);
@@ -256,6 +261,10 @@ pub async fn build(
             Network::Concordium(net) => {
                 concordium::register(&mut map, net, config, lookup, &cache).await?;
             }
+            #[cfg(feature = "experimental-tron")]
+            Network::Tron(net) => {
+                tron::register(&mut map, net, config, lookup, &cache)?;
+            }
         }
     }
     #[cfg(feature = "evm")]
@@ -275,7 +284,8 @@ pub async fn build(
     feature = "keeta",
     feature = "tvm",
     feature = "stellar",
-    feature = "concordium"
+    feature = "concordium",
+    feature = "experimental-tron"
 ))]
 pub(super) fn named_secret(
     config: &Config,

--- a/crates/facilitator/src/compose/tron.rs
+++ b/crates/facilitator/src/compose/tron.rs
@@ -1,0 +1,103 @@
+//! Tron provider + exact facilitator wiring.
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_signer_local::PrivateKeySigner;
+use compact_str::CompactString;
+use r402_facilitator::SettlementCache;
+use r402_protocol::ChainId;
+use r402_protocol::ExactScheme;
+use r402_protocol::scheme::SchemeSlug;
+use r402_tron::TronExactFacilitator;
+use r402_tron::chain::{TronChainProvider, TronChainProviderConfig, TronChainReference};
+use url::Url;
+
+use super::{FacilitatorMap, named_secret, scheme_not_enabled};
+use crate::config::{Config, RpcEndpoint, TronNetwork, resolve_rpc};
+use crate::error::Error;
+
+/// Default `fee_limit` in SUN when the network table omits it.
+const DEFAULT_FEE_LIMIT_SUN: u64 = 100_000_000;
+
+/// Default confirmation wait (Tron blocks are ~3s).
+const DEFAULT_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default poll interval for `gettransactioninfobyid`.
+const DEFAULT_CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Register Tron exact for `network`.
+///
+/// [`TronChainProvider::new`] does not dial; settlement talks to `TronGrid` later.
+pub(super) fn register(
+    map: &mut FacilitatorMap,
+    network: &TronNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+    cache: &SettlementCache,
+) -> Result<(), Error> {
+    for name in &network.schemes {
+        if name.as_str() != ExactScheme::VALUE {
+            return Err(scheme_not_enabled(name, &network.chain_id));
+        }
+    }
+    let facilitator = TronExactFacilitator::with_settlement_cache(
+        provider(network, config, lookup)?,
+        cache.clone(),
+    );
+    insert_scheme(map, network, ExactScheme::VALUE, facilitator)
+}
+
+fn provider(
+    network: &TronNetwork,
+    config: &Config,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<TronChainProvider, Error> {
+    let chain = TronChainReference::try_from(network.chain_id.clone()).map_err(|err| {
+        Error::config_with(format!("invalid Tron chain id '{}'", network.chain_id), err)
+    })?;
+    let endpoints = resolve_rpc(&network.chain_id, &network.rpc, lookup)?;
+    let base_url = tron_base_url(&network.chain_id, &endpoints)?;
+    let secret = named_secret(config, &network.signer, lookup)?;
+    let signer = PrivateKeySigner::from_str(&secret).map_err(|err| {
+        Error::config_with(
+            format!(
+                "signer '{}' is not a valid secp256k1 hex key",
+                network.signer
+            ),
+            err,
+        )
+    })?;
+    Ok(TronChainProvider::new(TronChainProviderConfig {
+        chain_reference: chain,
+        base_url,
+        signer,
+        fee_limit: network.fee_limit.unwrap_or(DEFAULT_FEE_LIMIT_SUN),
+        confirmation_timeout: network
+            .confirmation_timeout
+            .unwrap_or(DEFAULT_CONFIRMATION_TIMEOUT),
+        confirmation_poll_interval: network
+            .confirmation_poll_interval
+            .unwrap_or(DEFAULT_CONFIRMATION_POLL_INTERVAL),
+    }))
+}
+
+fn tron_base_url(chain_id: &ChainId, endpoints: &[RpcEndpoint]) -> Result<Url, Error> {
+    let Some(endpoint) = endpoints.first() else {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] has no RPC URL"
+        )));
+    };
+    Ok(endpoint.url.clone())
+}
+
+fn insert_scheme(
+    map: &mut FacilitatorMap,
+    network: &TronNetwork,
+    name: &'static str,
+    handler: TronExactFacilitator,
+) -> Result<(), Error> {
+    let slug = SchemeSlug::new(network.chain_id.clone(), CompactString::from(name));
+    map.insert(slug, Arc::new(handler))
+}

--- a/crates/facilitator/src/config/family.rs
+++ b/crates/facilitator/src/config/family.rs
@@ -11,7 +11,8 @@
     feature = "keeta",
     feature = "tvm",
     feature = "stellar",
-    feature = "concordium"
+    feature = "concordium",
+    feature = "experimental-tron"
 ))]
 use r402_protocol::scheme::SchemeId;
 
@@ -76,6 +77,9 @@ pub(crate) enum HostableFamily {
     /// Concordium (`ccd`).
     #[cfg(feature = "concordium")]
     Concordium,
+    /// Tron (experimental).
+    #[cfg(feature = "experimental-tron")]
+    Tron,
 }
 
 /// Namespace string for EIP-155, from the SDK when the `evm` feature is on.
@@ -239,6 +243,22 @@ const fn ccd_namespace() -> &'static str {
     "ccd"
 }
 
+/// Namespace string for Tron.
+#[allow(
+    clippy::missing_const_for_fn,
+    reason = "feature-on branch calls SchemeId::namespace, which is not const"
+)]
+fn tron_namespace() -> &'static str {
+    #[cfg(feature = "experimental-tron")]
+    {
+        r402_tron::TronExact.namespace()
+    }
+    #[cfg(not(feature = "experimental-tron"))]
+    {
+        "tron"
+    }
+}
+
 /// Cargo feature name for a known CAIP-2 namespace.
 #[must_use]
 pub(crate) fn family_feature(namespace: &str) -> Option<&'static str> {
@@ -275,10 +295,10 @@ pub(crate) fn family_feature(namespace: &str) -> Option<&'static str> {
     if namespace == ccd_namespace() {
         return Some("concordium");
     }
-    match namespace {
-        "tron" => Some("experimental-tron"),
-        _ => None,
+    if namespace == tron_namespace() {
+        return Some("experimental-tron");
     }
+    None
 }
 
 /// Whether `feature` is compiled into this binary.
@@ -357,6 +377,10 @@ pub(crate) fn classify(namespace: &str) -> FamilyStatus {
     #[cfg(feature = "concordium")]
     if namespace == ccd_namespace() {
         return FamilyStatus::Hostable(HostableFamily::Concordium);
+    }
+    #[cfg(feature = "experimental-tron")]
+    if namespace == tron_namespace() {
+        return FamilyStatus::Hostable(HostableFamily::Tron);
     }
     FamilyStatus::Reserved { feature }
 }
@@ -571,5 +595,26 @@ mod tests {
             ccd_namespace(),
             r402_concordium::ConcordiumExact::new().namespace()
         );
+    }
+
+    #[cfg(not(feature = "experimental-tron"))]
+    #[test]
+    fn tron_compiled_out() {
+        assert_eq!(
+            classify("tron"),
+            FamilyStatus::CompiledOut {
+                feature: "experimental-tron"
+            }
+        );
+    }
+
+    #[cfg(feature = "experimental-tron")]
+    #[test]
+    fn tron_hostable() {
+        assert_eq!(
+            classify("tron"),
+            FamilyStatus::Hostable(HostableFamily::Tron)
+        );
+        assert_eq!(tron_namespace(), r402_tron::TronExact.namespace());
     }
 }

--- a/crates/facilitator/src/config/mod.rs
+++ b/crates/facilitator/src/config/mod.rs
@@ -28,6 +28,8 @@ pub use network::NamedAccount;
 pub use network::NearNetwork;
 #[cfg(feature = "stellar")]
 pub use network::StellarNetwork;
+#[cfg(feature = "experimental-tron")]
+pub use network::TronNetwork;
 #[cfg(feature = "tvm")]
 pub use network::TvmNetwork;
 #[cfg(feature = "xrpl")]
@@ -393,6 +395,10 @@ fn resolve_network_env(
         #[cfg(feature = "concordium")]
         Network::Concordium(net) => {
             let _ = resolve_optional_grpc(&net.chain_id, net.grpc.as_ref(), lookup)?;
+        }
+        #[cfg(feature = "experimental-tron")]
+        Network::Tron(net) => {
+            let _ = resolve_rpc(&net.chain_id, &net.rpc, lookup)?;
         }
     }
     Ok(())

--- a/crates/facilitator/src/config/network.rs
+++ b/crates/facilitator/src/config/network.rs
@@ -1,6 +1,6 @@
 //! Per-network tables keyed by CAIP-2 id.
 
-#[cfg(feature = "concordium")]
+#[cfg(any(feature = "concordium", feature = "experimental-tron"))]
 use std::time::Duration;
 
 use r402_protocol::{AuthCaptureScheme, BatchSettlementScheme, ChainId, ExactScheme, UptoScheme};
@@ -64,6 +64,9 @@ pub enum Network {
     /// Concordium network.
     #[cfg(feature = "concordium")]
     Concordium(ConcordiumNetwork),
+    /// Tron network.
+    #[cfg(feature = "experimental-tron")]
+    Tron(TronNetwork),
 }
 
 impl Network {
@@ -91,6 +94,8 @@ impl Network {
             Self::Stellar(net) => &net.chain_id,
             #[cfg(feature = "concordium")]
             Self::Concordium(net) => &net.chain_id,
+            #[cfg(feature = "experimental-tron")]
+            Self::Tron(net) => &net.chain_id,
         }
     }
 
@@ -118,6 +123,8 @@ impl Network {
             Self::Stellar(net) => &net.schemes,
             #[cfg(feature = "concordium")]
             Self::Concordium(net) => &net.schemes,
+            #[cfg(feature = "experimental-tron")]
+            Self::Tron(net) => &net.schemes,
         }
     }
 
@@ -145,6 +152,8 @@ impl Network {
             Self::Stellar(net) => &net.signer_names,
             #[cfg(feature = "concordium")]
             Self::Concordium(net) => &net.signer_names,
+            #[cfg(feature = "experimental-tron")]
+            Self::Tron(net) => std::slice::from_ref(&net.signer),
         }
     }
 }
@@ -403,6 +412,26 @@ pub struct ConcordiumNetwork {
     pub finalization_timeout: Option<Duration>,
     /// Spec Rule 7 expiry cap; `None` uses the SDK default.
     pub max_expiry_offset_seconds: Option<u64>,
+}
+
+/// Parsed Tron `[network."<caip2>"]`.
+#[cfg(feature = "experimental-tron")]
+#[derive(Debug, Clone)]
+pub struct TronNetwork {
+    /// CAIP-2 id (`tron:0x2b6653dc` / `tron:0xcd8690dc`).
+    pub chain_id: ChainId,
+    /// `TronGrid` base URL; exactly one of `rpc` / `rpc_env`.
+    pub rpc: RpcConfig,
+    /// Named `[signer.*]` secp256k1 key.
+    pub signer: String,
+    /// Scheme names (`exact`).
+    pub schemes: Vec<String>,
+    /// Settlement `fee_limit` in SUN; `None` uses `100_000_000`.
+    pub fee_limit: Option<u64>,
+    /// Confirmation wait; `None` uses 30s.
+    pub confirmation_timeout: Option<Duration>,
+    /// Confirmation poll interval; `None` uses 1s.
+    pub confirmation_poll_interval: Option<Duration>,
 }
 
 /// RPC source: literal endpoints or one env var.
@@ -698,6 +727,31 @@ struct RawConcordiumAccount {
     signer: String,
 }
 
+#[cfg(feature = "experimental-tron")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawTronNetwork {
+    /// Literal `TronGrid` base URL.
+    #[serde(default)]
+    rpc: Option<String>,
+    /// Env name for the `TronGrid` base URL.
+    #[serde(default)]
+    rpc_env: Option<String>,
+    /// Named `[signer.*]` secp256k1 key.
+    signer: String,
+    /// Scheme names.
+    schemes: Vec<String>,
+    /// Settlement `fee_limit` in SUN.
+    #[serde(default)]
+    fee_limit: Option<u64>,
+    /// Confirmation wait.
+    #[serde(default, with = "humantime_serde::option")]
+    confirmation_timeout: Option<Duration>,
+    /// Confirmation poll interval.
+    #[serde(default, with = "humantime_serde::option")]
+    confirmation_poll_interval: Option<Duration>,
+}
+
 #[cfg(any(feature = "near", feature = "hedera"))]
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -735,6 +789,8 @@ pub(crate) fn parse_network(
         HostableFamily::Stellar => parse_stellar(chain_id, value).map(Network::Stellar),
         #[cfg(feature = "concordium")]
         HostableFamily::Concordium => parse_concordium(chain_id, value).map(Network::Concordium),
+        #[cfg(feature = "experimental-tron")]
+        HostableFamily::Tron => parse_tron(chain_id, value).map(Network::Tron),
     }
 }
 
@@ -1024,6 +1080,35 @@ fn parse_concordium(chain_id: &ChainId, value: toml::Value) -> Result<Concordium
     })
 }
 
+#[cfg(feature = "experimental-tron")]
+fn parse_tron(chain_id: &ChainId, value: toml::Value) -> Result<TronNetwork, Error> {
+    let raw: RawTronNetwork = value.try_into().map_err(|err: toml::de::Error| {
+        Error::config(format!("invalid [network.\"{chain_id}\"]: {err}"))
+    })?;
+    r402_tron::chain::TronChainReference::try_from(chain_id.clone())
+        .map_err(|err| Error::config_with(format!("invalid Tron chain id '{chain_id}'"), err))?;
+    let rpc = require_rpc(
+        chain_id,
+        raw.rpc.as_deref().map(single_rpc).transpose()?,
+        raw.rpc_env,
+    )?;
+    let schemes = require_schemes(chain_id, HostableFamily::Tron, raw.schemes)?;
+    if raw.signer.is_empty() {
+        return Err(Error::config(format!(
+            "[network.\"{chain_id}\"] `signer` must not be empty"
+        )));
+    }
+    Ok(TronNetwork {
+        chain_id: chain_id.clone(),
+        rpc,
+        signer: raw.signer,
+        schemes,
+        fee_limit: raw.fee_limit,
+        confirmation_timeout: raw.confirmation_timeout,
+        confirmation_poll_interval: raw.confirmation_poll_interval,
+    })
+}
+
 #[cfg(feature = "xrpl")]
 fn reject_xrpl_hot_wallet(chain_id: &ChainId, value: &toml::Value) -> Result<(), Error> {
     let Some(table) = value.as_table() else {
@@ -1149,7 +1234,7 @@ fn single_rpc(url: &str) -> Result<Vec<RpcEndpoint>, Error> {
     Ok(vec![endpoint_from_url(url)?])
 }
 
-/// EVM / SVM: exactly one of `rpc` / `rpc_env`.
+/// EVM / SVM / Tron: exactly one of `rpc` / `rpc_env`.
 fn require_rpc(
     chain_id: &ChainId,
     rpc: Option<Vec<RpcEndpoint>>,
@@ -1290,6 +1375,8 @@ const fn known_scheme_names(family: HostableFamily) -> &'static [&'static str] {
         HostableFamily::Stellar => &[ExactScheme::VALUE],
         #[cfg(feature = "concordium")]
         HostableFamily::Concordium => &[ExactScheme::VALUE],
+        #[cfg(feature = "experimental-tron")]
+        HostableFamily::Tron => &[ExactScheme::VALUE],
     }
 }
 

--- a/crates/facilitator/src/lib.rs
+++ b/crates/facilitator/src/lib.rs
@@ -36,6 +36,8 @@ pub use config::NamedAccount;
 pub use config::NearNetwork;
 #[cfg(feature = "stellar")]
 pub use config::StellarNetwork;
+#[cfg(feature = "experimental-tron")]
+pub use config::TronNetwork;
 #[cfg(feature = "tvm")]
 pub use config::TvmNetwork;
 #[cfg(feature = "xrpl")]

--- a/crates/facilitator/tests/compose_families.rs
+++ b/crates/facilitator/tests/compose_families.rs
@@ -1,5 +1,5 @@
-//! Compose: remaining exact families (near/xrpl/hedera/avm + aptos/keeta/tvm/stellar).
-//! Concordium `connect` dials gRPC — parse + signer error mapping only.
+//! Compose remaining exact families, including experimental-tron.
+//! Concordium `connect` dials gRPC; CI tests parse and signer errors only.
 
 #![allow(
     unused_crate_dependencies,
@@ -26,7 +26,8 @@
     feature = "keeta",
     feature = "tvm",
     feature = "stellar",
-    feature = "concordium"
+    feature = "concordium",
+    feature = "experimental-tron"
 ))]
 use facilitator::{build, parse_config_toml};
 #[cfg(any(
@@ -37,7 +38,8 @@ use facilitator::{build, parse_config_toml};
     feature = "aptos",
     feature = "keeta",
     feature = "tvm",
-    feature = "stellar"
+    feature = "stellar",
+    feature = "experimental-tron"
 ))]
 use r402_facilitator::Facilitator;
 #[cfg(any(feature = "near", feature = "hedera", feature = "aptos"))]
@@ -51,7 +53,8 @@ use r402_protocol::payment::SupportedResponse;
     feature = "avm",
     feature = "aptos",
     feature = "tvm",
-    feature = "stellar"
+    feature = "stellar",
+    feature = "experimental-tron"
 ))]
 const DUMMY_RPC: &str = "http://127.0.0.1:1";
 
@@ -85,6 +88,10 @@ const TVM_KEY: &str = "070707070707070707070707070707070707070707070707070707070
 #[cfg(feature = "stellar")]
 const STELLAR_KEY: &str = "SCKB3ECHCPVM4HJPNCQWTQWJJ5XRL6UNKLTTCIH4B7TB22NKJ5GUFMIV";
 
+/// Anvil account 0. Local signing only; never sent to a live chain.
+#[cfg(feature = "experimental-tron")]
+const TRON_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
 /// 32-byte Concordium seed as hex.
 #[cfg(feature = "concordium")]
 const CCD_KEY: &str = "1111111111111111111111111111111111111111111111111111111111111111";
@@ -102,7 +109,8 @@ const CCD_TESTNET: &str = "ccd:4221332d34e1694168c2a0c0b3fd0f27";
     feature = "keeta",
     feature = "tvm",
     feature = "stellar",
-    feature = "concordium"
+    feature = "concordium",
+    feature = "experimental-tron"
 ))]
 fn lookup(key: &str) -> Option<String> {
     match key {
@@ -122,6 +130,8 @@ fn lookup(key: &str) -> Option<String> {
         "FACILITATOR_STELLAR_KEY" => Some(STELLAR_KEY.to_owned()),
         #[cfg(feature = "concordium")]
         "FACILITATOR_CCD_KEY" => Some(CCD_KEY.to_owned()),
+        #[cfg(feature = "experimental-tron")]
+        "FACILITATOR_TRON_KEY" => Some(TRON_KEY.to_owned()),
         _ => None,
     }
 }
@@ -386,6 +396,38 @@ async fn concordium_invalid_key_is_startup_error() {
     );
 }
 
+#[cfg(feature = "experimental-tron")]
+#[tokio::test]
+async fn tron_exact_constructs() {
+    let cfg = parse_config_toml(&tron_doc()).expect("parse");
+    let map = build(&cfg, &lookup).await.expect("construct");
+    let supported = Facilitator::supported(&map).await.expect("supported");
+    assert_eq!(supported.kinds.len(), 1, "one kind");
+    let kind = &supported.kinds[0];
+    assert_eq!(kind.scheme.as_str(), "exact", "scheme");
+    assert_eq!(kind.network.as_str(), "tron:0x2b6653dc", "network");
+    assert!(
+        supported.signers.contains_key("tron:*"),
+        "tron:* signer key"
+    );
+}
+
+#[cfg(feature = "experimental-tron")]
+#[tokio::test]
+async fn tron_invalid_key_is_startup_error() {
+    let cfg = parse_config_toml(&tron_doc()).expect("parse");
+    let err = build(&cfg, &|key| {
+        (key == "FACILITATOR_TRON_KEY").then(|| "not-a-secp256k1-key".to_owned())
+    })
+    .await
+    .expect_err("bad key");
+    assert!(
+        err.to_string()
+            .contains("signer 'tron_hot' is not a valid secp256k1 hex key"),
+        "got {err}"
+    );
+}
+
 #[cfg(feature = "near")]
 fn near_doc() -> String {
     format!(
@@ -554,6 +596,26 @@ env = "FACILITATOR_CCD_KEY"
 
 [network."{CCD_TESTNET}"]
 signers = [{{ address = "{CCD_ADDRESS}", signer = "ccd_hot" }}]
+schemes = ["exact"]
+"#
+    )
+}
+
+#[cfg(feature = "experimental-tron")]
+fn tron_doc() -> String {
+    format!(
+        r#"
+[http]
+listen = "127.0.0.1:8080"
+settle_timeout = "30s"
+
+[signer.tron_hot]
+source = "env"
+env = "FACILITATOR_TRON_KEY"
+
+[network."tron:0x2b6653dc"]
+rpc = "{DUMMY_RPC}"
+signer = "tron_hot"
 schemes = ["exact"]
 "#
     )

--- a/crates/facilitator/tests/config.rs
+++ b/crates/facilitator/tests/config.rs
@@ -923,6 +923,99 @@ schemes = ["exact"]
     );
 }
 
+#[cfg(not(feature = "experimental-tron"))]
+#[test]
+fn compiled_out_tron_names_feature() {
+    let raw = r#"
+[signer.tron_hot]
+source = "env"
+env = "TRON_KEY"
+[network."tron:0x2b6653dc"]
+rpc = "https://api.trongrid.io"
+signer = "tron_hot"
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string().contains("compiled-out family 'tron'"),
+        "got {err}"
+    );
+    assert!(
+        err.to_string().contains("--features experimental-tron"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "experimental-tron")]
+#[test]
+fn tron_requires_exactly_one_rpc() {
+    let raw = r#"
+[signer.tron_hot]
+source = "env"
+env = "TRON_KEY"
+[network."tron:0x2b6653dc"]
+signer = "tron_hot"
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("exactly one of `rpc` or `rpc_env`"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "experimental-tron")]
+#[test]
+fn tron_rpc_and_rpc_env_are_exclusive() {
+    let raw = r#"
+[signer.tron_hot]
+source = "env"
+env = "TRON_KEY"
+[network."tron:0x2b6653dc"]
+rpc = "http://127.0.0.1:1"
+rpc_env = "TRON_RPC"
+signer = "tron_hot"
+schemes = ["exact"]
+"#;
+    let err = parse_config_toml(raw).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("exactly one of `rpc` or `rpc_env`"),
+        "got {err}"
+    );
+}
+
+#[cfg(feature = "experimental-tron")]
+#[test]
+fn tron_parses_rpc() {
+    let raw = r#"
+[signer.tron_hot]
+source = "env"
+env = "TRON_KEY"
+[network."tron:0x2b6653dc"]
+rpc = "http://127.0.0.1:1"
+signer = "tron_hot"
+schemes = ["exact"]
+"#;
+    let cfg = parse_config_toml(raw).expect("parse tron");
+    let tron = cfg.networks.iter().find_map(|net| {
+        if let Network::Tron(tron) = net {
+            Some(tron)
+        } else {
+            None
+        }
+    });
+    let tron = tron.expect("tron network");
+    assert_eq!(tron.signer, "tron_hot", "signer name");
+    assert_eq!(tron.schemes, ["exact".to_owned()], "exact only");
+    assert!(tron.fee_limit.is_none(), "compose default fee_limit");
+    assert!(
+        matches!(tron.rpc, facilitator::RpcConfig::Literal(_)),
+        "literal rpc"
+    );
+}
+
 #[test]
 fn casper_is_always_unhostable() {
     let raw = r#"


### PR DESCRIPTION
Host Tron exact behind Cargo feature experimental-tron. Default features
stay evm+svm. TronGrid URL requires exactly one of rpc/rpc_env. Construct
with TronExactFacilitator::with_settlement_cache and TronChainProvider::new.
Does not gate v2.0.0.
