### PR TITLE
release: 0.7.0 on r402 0.20 from crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,25 +25,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # crates/facilitator path-deps ../../../r402 → $GITHUB_WORKSPACE/../r402
-      # (/home/runner/work/facilitator/r402). actions/checkout cannot write
-      # outside GITHUB_WORKSPACE; clone into .ci/r402 and symlink there.
-      - name: Checkout r402 0.19.1
-        uses: actions/checkout@v5
-        with:
-          repository: qntx/r402
-          ref: v0.19.1
-          persist-credentials: false
-          path: .ci/r402
-
-      - name: Link r402 sibling for path deps
-        run: |
-          set -euo pipefail
-          dest="$(cd "$GITHUB_WORKSPACE/.." && pwd)/r402"
-          ln -sfn "$GITHUB_WORKSPACE/.ci/r402" "$dest"
-          test -f "$dest/crates/r402-protocol/Cargo.toml"
-          test -f "$dest/crates/r402-evm/Cargo.toml"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -54,19 +35,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      # --package facilitator: rustfmt --all also formats path-dep r402.
-      # nightly: rustfmt.toml group_imports is nightly-only.
       - name: Format
         run: cargo +nightly fmt --package facilitator --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
       - name: Build
-        run: cargo build --workspace --verbose
+        run: cargo build --workspace --locked --verbose
 
       - name: Test
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --locked --verbose
 
   ci-families:
     runs-on: ubuntu-latest
@@ -80,28 +59,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Checkout r402 0.19.1
-        uses: actions/checkout@v5
-        with:
-          repository: qntx/r402
-          ref: v0.19.1
-          persist-credentials: false
-          path: .ci/r402
-
-      - name: Link r402 sibling for path deps
-        run: |
-          set -euo pipefail
-          dest="$(cd "$GITHUB_WORKSPACE/.." && pwd)/r402"
-          ln -sfn "$GITHUB_WORKSPACE/.ci/r402" "$dest"
-          test -f "$dest/crates/r402-protocol/Cargo.toml"
-          test -f "$dest/crates/r402-near/Cargo.toml"
-          test -f "$dest/crates/r402-avm/Cargo.toml"
-          test -f "$dest/crates/r402-aptos/Cargo.toml"
-          test -f "$dest/crates/r402-concordium/Cargo.toml"
-          test -f "$dest/crates/r402-tron/Cargo.toml"
-
-      # hedera-proto (r402-hedera) runs prost-build. ubuntu-latest ships
-      # neither protoc nor google/protobuf/*.proto (wrappers.proto).
       - name: Install protobuf compiler
         run: |
           set -euo pipefail
@@ -117,7 +74,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy families
-        run: cargo clippy --workspace --all-targets --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium,experimental-tron -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium,experimental-tron -- -D warnings
 
       - name: Test families
-        run: cargo test --workspace --verbose --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium,experimental-tron
+        run: cargo test --workspace --locked --verbose --features near,xrpl,hedera,avm,aptos,keeta,tvm,stellar,concordium,experimental-tron

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,15 +1,15 @@
 name: Docker
 
 # Tag v* publishes to GHCR with SBOM + provenance attestation.
-# metadata-action flavor latest=auto: v2.0.0 also moves
-# ghcr.io/qntx/facilitator:latest and :2. Operators pin :2.0.0 or a digest.
+# metadata-action flavor latest=auto: v0.7.0 also moves
+# ghcr.io/qntx/facilitator:latest and :0. Operators pin :0.7.0 or a digest.
 # pull_request and workflow_dispatch are build-only (push: false, no SBOM).
 # linux/amd64 only: Dockerfile runs native cargo; dual-arch would QEMU-compile r402.
 #
 # Inlined rather than qntx/workflows publish-container.yml@v2.0.0: that
 # callee's mutually exclusive job `if:` on `inputs.push` / `inputs.attest`
 # produces startup_failure (0 jobs) when this repo calls it from a
-# pull_request. Dockerfile clones r402 itself; no extra checkout.
+# pull_request.
 
 on:
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    uses: qntx/workflows/.github/workflows/publish-crates.yml@v2.0.0
+    permissions:
+      contents: read
+    with:
+      packages: "facilitator"
+      apt-packages: protobuf-compiler libprotobuf-dev
+      timeout-minutes: 90
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "facilitator"
-version = "2.0.0"
+version = "0.7.0"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -6138,9 +6138,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -6528,7 +6528,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r402-aptos"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e901e38d37bccb38d5800622572b23ed9ec7c06e398f982cb167c1394fdbd445"
 dependencies = [
  "aptos-sdk",
  "base64 0.23.1",
@@ -6544,7 +6546,9 @@ dependencies = [
 
 [[package]]
 name = "r402-avm"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4331b6f621097306964c2797f462163eca53fee89399fbbd885b0df57e272879"
 dependencies = [
  "base64 0.23.1",
  "compact_str",
@@ -6564,7 +6568,9 @@ dependencies = [
 
 [[package]]
 name = "r402-client"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57365132877f43d2e7de30fb37690d8ff9f599216dacfbd69c64294a63bc43df"
 dependencies = [
  "compact_str",
  "http 1.5.0",
@@ -6573,7 +6579,9 @@ dependencies = [
 
 [[package]]
 name = "r402-concordium"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fad7f6d33713d00c6213363b75f9252c635479bfcbbd5d718ff22bdb20fcf5"
 dependencies = [
  "bs58 0.5.1",
  "compact_str",
@@ -6593,7 +6601,9 @@ dependencies = [
 
 [[package]]
 name = "r402-evm"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9be187aaf1525bd4e487293805ef4170390cde97ec93c015919f89e923f274"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -6627,7 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "r402-extensions"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b552727db1d4cbf65a074ecbb72d43e26b3cf5a1156ed55c1e6433f3d548326e"
 dependencies = [
  "compact_str",
  "r402-client",
@@ -6638,7 +6650,9 @@ dependencies = [
 
 [[package]]
 name = "r402-facilitator"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b15e800c9982cea76c9db113372b8111a40eca64857a6f1cdda208f4e7b8ef2"
 dependencies = [
  "compact_str",
  "metrics",
@@ -6648,7 +6662,9 @@ dependencies = [
 
 [[package]]
 name = "r402-hedera"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc37c3a0d4767aa5ee52f51850d2287ee50fa03be7ac4dbb0cb5fdcdab8e2672"
 dependencies = [
  "base64 0.23.1",
  "compact_str",
@@ -6666,7 +6682,9 @@ dependencies = [
 
 [[package]]
 name = "r402-keeta"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1df72664c156f8df69297b9a0363afadfd185c5de426b4d4e243ccaff5b5fa1"
 dependencies = [
  "base64 0.23.1",
  "compact_str",
@@ -6686,7 +6704,9 @@ dependencies = [
 
 [[package]]
 name = "r402-near"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cde55503155ea1359ee85468fab49bececa471566ef80c2367d17db1aa5c20"
 dependencies = [
  "base64 0.23.1",
  "borsh",
@@ -6698,6 +6718,7 @@ dependencies = [
  "near-primitives",
  "r402-facilitator",
  "r402-protocol",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6708,7 +6729,9 @@ dependencies = [
 
 [[package]]
 name = "r402-protocol"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b244a6e2781260cd3b21643fd4393de617630208a7f463fe36f4074f2be7b2"
 dependencies = [
  "base64 0.23.1",
  "compact_str",
@@ -6721,7 +6744,9 @@ dependencies = [
 
 [[package]]
 name = "r402-stellar"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507de4e6ad13e12de2c04447b2b02f4b27153551f7827dd7d8bfe4ea8dff47be"
 dependencies = [
  "compact_str",
  "ed25519-dalek 3.0.0",
@@ -6741,7 +6766,9 @@ dependencies = [
 
 [[package]]
 name = "r402-svm"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f12367e91c2bbf111c2300cb62985b982bc68c0367ad041265bd2016b0fd41"
 dependencies = [
  "base64 0.23.1",
  "bincode",
@@ -6774,7 +6801,9 @@ dependencies = [
 
 [[package]]
 name = "r402-tron"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5b311bc590af32fa27310fdfab7ceee42e9827d0cec4a76f1ad62859d73793"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6797,7 +6826,9 @@ dependencies = [
 
 [[package]]
 name = "r402-tvm"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47be2b0469da720981772909ae2972474c304473514de9a621457e961d5dae8"
 dependencies = [
  "base64 0.23.1",
  "compact_str",
@@ -6821,7 +6852,9 @@ dependencies = [
 
 [[package]]
 name = "r402-xrpl"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae8fb616f73cf66249c0131c621d30f3e374af3c7e5a770876bc63c3511be0b"
 dependencies = [
  "compact_str",
  "hex",
@@ -12050,9 +12083,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882"
 dependencies = [
  "zstd-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/facilitator"]
 resolver = "3"
 
 [workspace.package]
-version = "2.0.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,11 @@
 # Multi-stage build. Runtime is distroless (no shell, no curl).
 # HEALTHCHECK is omitted: compose/k8s HTTP probes on /healthz and /readyz.
 #
-# Path deps: crates/facilitator → ../../../r402. The builder clones
-# qntx/r402 at R402_REF (default v0.19.1) next to this repo.
-#
-#   docker build -t ghcr.io/qntx/facilitator:2.0.0 .
+#   docker build -t ghcr.io/qntx/facilitator:0.7.0 .
 
 ARG RUST_VERSION=1.95
 
 FROM rust:${RUST_VERSION}-bookworm AS builder
-
-ARG R402_REF=v0.19.1
-ENV GIT_TERMINAL_PROMPT=0
-RUN git clone --depth 1 --branch "${R402_REF}" https://github.com/qntx/r402.git /src/r402 \
-    && test -f /src/r402/crates/r402-protocol/Cargo.toml
 
 WORKDIR /src/facilitator
 COPY . .

--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,7 @@ clippy-fix:
         --allow-staged \
         -- -D warnings
 
-# Format facilitator only; rustfmt --all also formats path-dep r402.
+# Format facilitator only.
 fmt:
     cargo +nightly fmt --package facilitator
 

--- a/README.md
+++ b/README.md
@@ -1,211 +1,110 @@
+<!-- markdownlint-disable MD033 MD041 MD036 -->
+
 # Facilitator
 
+[![Crates.io][crates-badge]][crates-url]
+[![Docs.rs][docs-badge]][docs-url]
 [![CI][ci-badge]][ci-url]
 [![License][license-badge]][license-url]
 [![Rust][rust-badge]][rust-url]
 
+[crates-badge]: https://img.shields.io/crates/v/facilitator.svg
+[crates-url]: https://crates.io/crates/facilitator
+[docs-badge]: https://img.shields.io/docsrs/facilitator.svg
+[docs-url]: https://docs.rs/facilitator
 [ci-badge]: https://github.com/qntx/facilitator/actions/workflows/ci.yml/badge.svg
 [ci-url]: https://github.com/qntx/facilitator/actions/workflows/ci.yml
 [license-badge]: https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg
-[license-url]: #license
-[rust-badge]: https://img.shields.io/badge/rust-1.95%20%2B%20edition%202024-orange.svg
+[license-url]: LICENSE-MIT
+[rust-badge]: https://img.shields.io/badge/rust-edition%202024-orange.svg
 [rust-url]: https://doc.rust-lang.org/edition-guide/
 
-**[x402](https://www.x402.org/) V2 facilitator process** — verifies payment payloads and settles transactions on-chain over HTTP.
+**[x402](https://www.x402.org/) V2 facilitator** — verify payment payloads and settle on-chain over HTTP.
 
-Built on [r402](https://github.com/qntx/r402) **0.19.1**. This is facilitator 2.0: there is no compatibility with 1.0.0 config, r402 0.17, `/health`, Watchtower, or `fctl`. Replace `config.toml`; do not convert.
+Built on [r402](https://github.com/qntx/r402) **0.20**. Spec §7 (`POST /verify`, `POST /settle`, `GET /supported`) plus `/healthz`, `/readyz`, and an optional metrics listen. Default image hosts EVM `exact` / `upto` / `auth-capture` / `batch-settlement` and SVM `exact` / `upto`. One replica; settlement state is process-local.
 
-This process constructs in-process EVM `exact`/`upto`/`auth-capture`/`batch-settlement` and SVM `exact`/`upto` facilitators (one provider `Arc` per network, process `SettlementCache`). SVM upto uses process-wide `InMemoryChannelStorage`; Path 2 is a startup error. r402 0.19.1 has no rent-cleanup manager. Serves spec §7 HTTP plus `/healthz`, `/readyz`, and an optional metrics listen. A listed scheme without a constructor, or an empty constructed map, is a startup error.
-
-v1 is a **single replica**. In-memory stores are process-local. Enabling `batch-settlement` logs `batch-settlement requires a single replica` at startup.
-
-`crates/facilitator` path-depends on a **sibling** r402 checkout (`../../../r402/crates/...` from that crate). Clone both repos next to each other; CI clones `qntx/r402` at tag `v0.19.1` into the same layout.
-
-```text
-<parent>/
-  facilitator/    # this repo
-  r402/           # git clone --branch v0.19.1 https://github.com/qntx/r402
-```
+Casper cannot be hosted (`r402-casper` is a remote HTTP client). Tron is `experimental-tron` and is not in the default image.
 
 ## Quick Start
 
 ```bash
-# from <parent>/facilitator, with <parent>/r402 present
-cargo run -p facilitator -- init
-# edit config.toml — named [signer.*] tables, env/file secrets only
-cargo run -p facilitator -- validate -c config.toml
-cargo run -p facilitator -- serve -c config.toml
+cargo install facilitator
+facilitator init
+# edit config.toml — named [signer.*], env or file secrets only
+facilitator serve
 ```
 
 Requires **Rust 1.95**.
-
-## API
-
-| Method | Path | Description |
-| --- | --- | --- |
-| `POST` | `/verify` | Verify a payment payload (spec §7.1) |
-| `POST` | `/settle` | Settle a payment (spec §7.2) |
-| `GET` | `/supported` | List supported payment kinds (version / scheme / network) |
-| `GET` | `/healthz` | Liveness |
-| `GET` | `/readyz` | Readiness (200 when at least one kind is registered) |
-| `GET` | `/metrics` | Prometheus text; **metrics listen only**, never the protocol port |
-
-There is no `GET /` and no `GET /health`. Optional `[http.auth]` requires `Authorization: Bearer` on `/verify`, `/settle`, and `/supported`. Ops routes stay unauthenticated.
-
-## CLI
-
-```text
-facilitator <COMMAND>
-
-Commands:
-  init       Write config.example.toml-equivalent to PATH
-  validate   Load config, construct facilitators, print /supported JSON
-  serve      Bind and run
-
-Options:
-  -c, --config <PATH>   default: config.toml; env: FACILITATOR_CONFIG
-```
-
-`init --force` overwrites. `validate` and `serve` construct listed schemes. Unknown scheme **names** fail at parse; a listed scheme this build cannot construct fails at startup.
-
-## Configuration
-
-See [`config.example.toml`](config.example.toml) (EVM `schemes = ["exact", "upto"]`) and [`config.example.full.toml`](config.example.full.toml) (same plus SVM `exact` and `upto`).
-
-Named `[signer.*]` plus per-network references. Literal private keys, `settlement_mode`, `[signers]`, and `[[schemes]]` are startup errors.
-
-Env overlay: `FACILITATOR_HTTP_LISTEN`, `FACILITATOR_HTTP_METRICS_LISTEN`, `FACILITATOR_LOG_LEVEL`, `RUST_LOG`, `FACILITATOR_CONFIG`.
-
-## Deploy
-
-Image tag: `ghcr.io/qntx/facilitator:2.0.0`. Default features are `evm` + `svm`. Runtime is [`gcr.io/distroless/cc-debian12:nonroot`](https://github.com/GoogleContainerTools/distroless) (CA certs, no shell, no curl). There is no image `HEALTHCHECK`; probe `GET /healthz` and `GET /readyz`.
-
-v1 is **one replica**. [`deploy/k8s/deployment.yaml`](deploy/k8s/deployment.yaml) pins `replicas: 1` and `strategy: Recreate`. Do not add HPA. `SettlementCache`, pending stores, and SVM upto channel index are process-local. Duplicate `/settle` across replicas is unsafe. Pin `:2.0.0` or a digest; do not use Watchtower or `fctl`. Tag `v*` also moves `:latest` and `:2` (org `docker/metadata-action` flavor `latest=auto`).
-
-Drain is `settle_timeout + 5s` (default 35s): compose `stop_grace_period: 35s`, systemd `TimeoutStopSec=35`, k8s `terminationGracePeriodSeconds: 35`.
-
-`FACILITATOR_EVM_KEY` is required for the example config. An empty key is a construct failure.
-
-### Docker Compose (local)
-
-[`compose.yaml`](compose.yaml) mounts [`config.example.toml`](config.example.toml) (EVM `exact`+`upto`) and overlays `FACILITATOR_HTTP_LISTEN=0.0.0.0:8080` and `FACILITATOR_HTTP_METRICS_LISTEN=0.0.0.0:9090`.
 
 ```bash
 export FACILITATOR_EVM_KEY=0x...
 docker compose up --build
 ```
 
-SVM overlay: set `FACILITATOR_CONFIG` to [`config.example.full.toml`](config.example.full.toml) and add [`compose.svm.yaml`](compose.svm.yaml) (fee-payer key at `/run/secrets/solana.key`).
+Image: `ghcr.io/qntx/facilitator:0.7.0`. Pin that tag or a digest.
 
-```bash
-export FACILITATOR_EVM_KEY=0x...
-export FACILITATOR_CONFIG=./config.example.full.toml
-export SVM_FEE_PAYER_KEY=./solana.key
-docker compose -f compose.yaml -f compose.svm.yaml up --build
-```
+## API
 
-### TLS (Caddy)
-
-Optional compose profile. Edit the hostname in [`deploy/Caddyfile`](deploy/Caddyfile). Caddy does not proxy `/metrics`.
-
-```bash
-export FACILITATOR_EVM_KEY=0x...
-docker compose -f deploy/compose.yaml --profile tls up --build
-```
-
-Protocol is on loopback `:8080`; metrics on loopback `:9090`; Caddy on `:80`/`:443`.
-
-### systemd
-
-```bash
-sudo useradd --system --home /etc/facilitator --shell /usr/sbin/nologin facilitator
-sudo install -D -m 0755 target/release/facilitator /usr/bin/facilitator
-sudo install -d -m 0755 /etc/facilitator
-sudo install -m 0600 -o facilitator -g facilitator config.toml /etc/facilitator/config.toml
-sudo install -m 0644 deploy/systemd/facilitator.service /etc/systemd/system/facilitator.service
-# optional: /etc/facilitator/env  (FACILITATOR_EVM_KEY=..., RUST_LOG=...)
-sudo systemctl daemon-reload
-sudo systemctl enable --now facilitator
-```
-
-[`deploy/systemd/facilitator.service`](deploy/systemd/facilitator.service): `Type=simple`, `Restart=on-failure`, `EnvironmentFile=-/etc/facilitator/env`, `ExecStart=/usr/bin/facilitator serve -c /etc/facilitator/config.toml`, `TimeoutStopSec=35`.
-
-### Kubernetes
-
-[`deploy/k8s`](deploy/k8s): `replicas: 1`, `strategy: Recreate`, probes on protocol `/healthz` and `/readyz`, protocol Service 8080 only, headless metrics Service + ServiceMonitor on pod IP:9090.
-
-```bash
-# replace facilitator-secrets.evm.key first
-kubectl apply -k deploy/k8s
-```
-
-Default ConfigMap is EVM-only. SVM is opt-in (do not add the volume item until the Secret has the key — kubelet fails the mount):
-
-1. Put a base58 fee-payer in `facilitator-secrets` as `solana.key` (see [`deploy/k8s/secret.yaml`](deploy/k8s/secret.yaml)).
-2. Mount it: add `key: solana.key` / `path: solana.key` under the secrets volume `items` in [`deploy/k8s/deployment.yaml`](deploy/k8s/deployment.yaml).
-3. Copy SVM tables from [`config.example.full.toml`](config.example.full.toml) into the ConfigMap (`[signer.svm_fee]` `path = "/run/secrets/solana.key"`).
-
-Local equivalent: [`compose.svm.yaml`](compose.svm.yaml) with `FACILITATOR_CONFIG=./config.example.full.toml`.
-
-### Image
-
-```bash
-docker build -t ghcr.io/qntx/facilitator:2.0.0 .
-```
-
-The builder clones `qntx/r402` at tag `v0.19.1` (`--build-arg R402_REF=...` to override) so the crate path deps resolve. CI publishes `ghcr.io/qntx/facilitator` on `v*` tags with buildx SBOM and provenance attestation. Pull requests and `workflow_dispatch` only prove the image builds (no push, no SBOM). metadata-action also moves `:latest` and `:2`; pin `:2.0.0` or a digest.
-
-### Runbook
-
-v1 ops model is one replica. `replicas: 1`, `strategy: Recreate`, no HPA. Duplicate `/settle` splits the in-memory `SettlementCache`. On listen the JSON log fields are `settlement_cache` (`"in-memory"`) and `pin_settle` (`true`).
-
-Alert on:
-
-| Signal | Meaning |
-| --- | --- |
-| `r402_facilitator_settle_total{result="failure"}` / `{result="error"}` | settle failed or transport/timeout |
-| HTTP `invalidReason` / `errorReason` `invalid_transaction_state` | Onchain reject; HTTP 200, not 502 |
-| `GET /readyz` 503 | empty constructed map / not ready |
-| process down / `GET /healthz` | liveness |
-
-Gas exhaustion is Onchain, not HTTP 502.
-
-Rotate keys by rewriting secret files (or the Secret) and restarting. Crash-only; no hot reload.
-
-Rollback is the previous **2.x** image plus matching config. Cannot roll to 1.0.0. 1.0.0 config will not parse (`deny_unknown_fields`). Replace `config.toml`; do not convert.
-
-Tag `v*` publishes `ghcr.io/qntx/facilitator:2.0.0`. Org metadata-action flavor `latest=auto` also moves `:latest` and `:2`. Pin `:2.0.0` or a digest after first publish. Do not run `:latest` under Watchtower.
-
-This crate path-depends on sibling `r402` (`../../../r402/crates/...` from `crates/facilitator`). Local builds need `qntx/r402` at tag `v0.19.1` next to this repo. The Docker builder clones that tag. The operator is not published to crates.io.
-
-Casper is unhostable: `r402-casper` 0.19.1 `CasperExactFacilitator` is a remote HTTP client, not an on-chain facilitator. Do not proxy `casper:*`. No Cargo feature hosts it.
-
-Tron is `experimental-tron` and is not in the default image.
-
-## Feature Flags
-
-| Feature | Default | Description |
+| Method | Path | Description |
 | --- | --- | --- |
-| `evm` | ✓ | Parse EIP-155 tables and construct `exact`, `upto`, `auth-capture`, `batch-settlement` |
-| `svm` | ✓ | Parse Solana tables and construct `exact` and `upto` |
-| `telemetry` | ✓ | Reserved for OTLP |
-| `metrics` | ✓ | Enables `r402-facilitator/metrics` |
-| `near` / `xrpl` / `hedera` / `avm` / `aptos` / `keeta` / `tvm` / `stellar` / `concordium` | | Host `exact` when the feature is on |
-| `experimental-tron` | | Host `exact` when rebuilt with this feature; not in the default image |
+| `POST` | `/verify` | Verify a payment payload (§7.1) |
+| `POST` | `/settle` | Settle a payment (§7.2) |
+| `GET` | `/supported` | Supported kinds |
+| `GET` | `/healthz` | Liveness |
+| `GET` | `/readyz` | Ready when at least one kind is registered |
+| `GET` | `/metrics` | Prometheus text; **metrics listen only** |
 
-`casper:*` is always a remote-client startup error. There is no `extra-casper` feature.
+No `GET /`. Optional `[http.auth]` bearer applies to `/verify`, `/settle`, `/supported`. Ops routes are unauthenticated.
 
-Schemes are config lists, not Cargo features. If `evm` is compiled, `exact` / `upto` / `auth-capture` / `batch-settlement` are known **names**.
+```text
+facilitator init | validate | serve
+  -c, --config <PATH>   default: config.toml; env: FACILITATOR_CONFIG
+```
 
-## Security
+`validate` and `serve` construct listed schemes. Unknown scheme names fail at parse; a listed scheme this build cannot construct fails at startup.
 
-See [`SECURITY.md`](SECURITY.md) for disclaimers, supported versions, and vulnerability reporting.
+## Configuration
+
+[`config.example.toml`](config.example.toml) (EVM) and [`config.example.full.toml`](config.example.full.toml) (EVM + SVM). Named `[signer.*]` plus per-network references. Literal private keys are a startup error.
+
+```toml
+[signer.evm_hot]
+source = "env"
+env = "FACILITATOR_EVM_KEY"
+
+[network."eip155:84532"]
+rpc = ["https://sepolia.base.org"]
+signers = ["evm_hot"]
+schemes = ["exact", "upto"]
+```
+
+Env overlay: `FACILITATOR_HTTP_LISTEN`, `FACILITATOR_HTTP_METRICS_LISTEN`, `FACILITATOR_LOG_LEVEL`, `RUST_LOG`, `FACILITATOR_CONFIG`.
+
+## Features
+
+| Feature | Default | |
+| --- | --- | --- |
+| `evm` | ✓ | EIP-155 `exact` / `upto` / `auth-capture` / `batch-settlement` |
+| `svm` | ✓ | Solana `exact` / `upto` |
+| `telemetry` / `metrics` | ✓ | |
+| `near` `xrpl` `hedera` `avm` `aptos` `keeta` `tvm` `stellar` `concordium` | | `exact` |
+| `experimental-tron` | | `exact`; not in the default image |
+
+Schemes are config lists, not Cargo features.
+
+## Deploy
+
+Runtime is [`gcr.io/distroless/cc-debian12:nonroot`](https://github.com/GoogleContainerTools/distroless). Probe `/healthz` and `/readyz`. Drain is `settle_timeout + 5s` (default 35s).
+
+- Compose: [`compose.yaml`](compose.yaml), SVM overlay [`compose.svm.yaml`](compose.svm.yaml), TLS profile [`deploy/compose.yaml`](deploy/compose.yaml)
+- systemd: [`deploy/systemd/facilitator.service`](deploy/systemd/facilitator.service)
+- Kubernetes: [`deploy/k8s`](deploy/k8s) — `replicas: 1`, `strategy: Recreate`
 
 ## Acknowledgments
 
 - [r402](https://github.com/qntx/r402) — modular Rust SDK for the x402 payment protocol
 - [x402 Protocol Specification](https://www.x402.org/) — protocol design by Coinbase
-- [coinbase/x402](https://github.com/coinbase/x402) — official reference implementations (TypeScript, Python, Go)
+- [coinbase/x402](https://github.com/coinbase/x402) — official reference implementations
 
 ## License
 
@@ -217,3 +116,15 @@ Licensed under either of:
 at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this project shall be dual-licensed as above, without any additional terms or conditions.
+
+---
+
+<div align="center">
+
+A **[QuantX](https://qntx.org)** open-source project.
+
+<a href="https://qntx.org"><img alt="QuantX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx.svg" /></a>
+
+Code is law. We write both.
+
+</div>

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/qntx/facilitator:2.0.0
+    image: ghcr.io/qntx/facilitator:0.7.0
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/config.example.full.toml
+++ b/config.example.full.toml
@@ -63,7 +63,7 @@ max_channel_lifetime_secs = 3600
 # max_required_signatures
 # compute_unit_price_micro_lamports
 # settle_compute_unit_limit
-# v1 is one replica: InMemoryChannelStorage is process-local. r402 0.19.1
+# One replica: InMemoryChannelStorage is process-local. r402 0.20
 # does not expose a rent-cleanup manager; restart drops the channel index
 # and Distributed-channel rent is not reclaimed. verify/settle still run.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,4 +1,4 @@
-# config.example.toml — x402 facilitator 2.0 (r402 0.19)
+# config.example.toml — x402 facilitator 0.7 (r402 0.20)
 # Secrets: env or file. Literals for private keys are a startup error.
 
 [http]

--- a/crates/facilitator/Cargo.toml
+++ b/crates/facilitator/Cargo.toml
@@ -63,9 +63,8 @@ compact_str = { workspace = true }
 humantime-serde = { workspace = true }
 metrics = { workspace = true, optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
-# Sibling repo: <parent>/r402 (CI clones qntx/r402@v0.19.1 to that path).
-r402-facilitator = { version = "0.19.1", path = "../../../r402/crates/r402-facilitator", default-features = false }
-r402-protocol = { version = "0.19.1", path = "../../../r402/crates/r402-protocol" }
+r402-facilitator = { version = "0.20", default-features = false }
+r402-protocol = "0.20"
 serde = { workspace = true }
 serde_json = { workspace = true }
 subtle = { workspace = true }
@@ -77,19 +76,19 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
-r402-evm = { version = "0.19.1", path = "../../../r402/crates/r402-evm", default-features = false, features = ["facilitator"], optional = true }
-r402-extensions = { version = "0.19.1", path = "../../../r402/crates/r402-extensions", default-features = false, features = ["ext-builder-code", "ext-erc20-approval"], optional = true }
-r402-svm = { version = "0.19.1", path = "../../../r402/crates/r402-svm", default-features = false, features = ["facilitator"], optional = true }
-r402-near = { version = "0.19.1", path = "../../../r402/crates/r402-near", default-features = false, optional = true }
-r402-xrpl = { version = "0.19.1", path = "../../../r402/crates/r402-xrpl", default-features = false, optional = true }
-r402-hedera = { version = "0.19.1", path = "../../../r402/crates/r402-hedera", default-features = false, optional = true }
-r402-avm = { version = "0.19.1", path = "../../../r402/crates/r402-avm", default-features = false, optional = true }
-r402-aptos = { version = "0.19.1", path = "../../../r402/crates/r402-aptos", default-features = false, optional = true }
-r402-keeta = { version = "0.19.1", path = "../../../r402/crates/r402-keeta", default-features = false, optional = true }
-r402-tvm = { version = "0.19.1", path = "../../../r402/crates/r402-tvm", default-features = false, optional = true }
-r402-stellar = { version = "0.19.1", path = "../../../r402/crates/r402-stellar", default-features = false, optional = true }
-r402-concordium = { version = "0.19.1", path = "../../../r402/crates/r402-concordium", default-features = false, optional = true }
-r402-tron = { version = "0.19.1", path = "../../../r402/crates/r402-tron", default-features = false, optional = true }
+r402-evm = { version = "0.20", default-features = false, features = ["facilitator"], optional = true }
+r402-extensions = { version = "0.20", default-features = false, features = ["ext-builder-code", "ext-erc20-approval"], optional = true }
+r402-svm = { version = "0.20", default-features = false, features = ["facilitator"], optional = true }
+r402-near = { version = "0.20", default-features = false, optional = true }
+r402-xrpl = { version = "0.20", default-features = false, optional = true }
+r402-hedera = { version = "0.20", default-features = false, optional = true }
+r402-avm = { version = "0.20", default-features = false, optional = true }
+r402-aptos = { version = "0.20", default-features = false, optional = true }
+r402-keeta = { version = "0.20", default-features = false, optional = true }
+r402-tvm = { version = "0.20", default-features = false, optional = true }
+r402-stellar = { version = "0.20", default-features = false, optional = true }
+r402-concordium = { version = "0.20", default-features = false, optional = true }
+r402-tron = { version = "0.20", default-features = false, optional = true }
 solana-keypair = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/facilitator/src/compose/mod.rs
+++ b/crates/facilitator/src/compose/mod.rs
@@ -149,7 +149,7 @@ impl Facilitator for FacilitatorMap {
 /// Stellar, Concordium, and Tron exact share that cache too. NEAR and XRPL
 /// use private cache types (one per process). SVM upto uses `new`,
 /// `with_storage`, and `with_pending_store` (no settlement-cache constructor;
-/// r402 0.19.1 has no rent-cleanup manager). Auth-capture uses
+/// r402 0.20 has no rent-cleanup manager). Auth-capture uses
 /// `try_new(provider)` only. Batch-settlement uses `with_store` with a
 /// process-wide in-memory channel store. Path 2 is a startup error. A listed
 /// scheme without a constructor in this build is an error. The returned map

--- a/crates/facilitator/src/compose/svm.rs
+++ b/crates/facilitator/src/compose/svm.rs
@@ -2,7 +2,7 @@
 //!
 //! Exact and upto share one [`SolanaChainProvider`] per network (CU limits
 //! live on the network table). Upto uses process-wide
-//! [`InMemoryChannelStorage`]; r402 0.19.1 does not expose a rent-cleanup
+//! [`InMemoryChannelStorage`]; r402 0.20 does not expose a rent-cleanup
 //! manager, so the channel index is lost on restart and Distributed-channel
 //! rent is not reclaimed. v1 is a single replica.
 
@@ -91,7 +91,7 @@ impl Prepare {
     ) -> Result<(), Error> {
         // No settlement-cache constructor. `new` allocates private storage and
         // pending; override both so every SVM upto handler shares the process
-        // stores. r402 0.19.1 has no rent-cleanup manager to spawn.
+        // stores. r402 0.20 has no rent-cleanup manager to spawn.
         let config = upto_config(&self.upto, network.upto.as_ref());
         let facilitator = SolanaUptoFacilitator::new(Arc::clone(provider), config)
             .with_storage(Arc::clone(&self.storage))

--- a/crates/facilitator/src/config/family.rs
+++ b/crates/facilitator/src/config/family.rs
@@ -16,11 +16,10 @@
 ))]
 use r402_protocol::scheme::SchemeId;
 
-/// Casper is a remote HTTP client in r402 0.19.1; never hosted.
-pub(crate) const CASPER_UNHOSTABLE: &str = "casper exact cannot be hosted: r402-casper 0.19.1 \
+/// Casper is a remote HTTP client; never hosted.
+pub(crate) const CASPER_UNHOSTABLE: &str = "casper exact cannot be hosted: r402-casper \
      CasperExactFacilitator is a remote HTTP client \
-     (crates/r402-casper/src/exact/facilitator/mod.rs try_new(transport)), \
-     not an on-chain facilitator";
+     (try_new(transport)), not an on-chain facilitator";
 
 /// Outcome of classifying a CAIP-2 namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/facilitator/src/config/mod.rs
+++ b/crates/facilitator/src/config/mod.rs
@@ -1,4 +1,4 @@
-//! TOML config schema for facilitator 2.0.
+//! TOML config schema.
 
 mod family;
 mod http;

--- a/crates/facilitator/src/lib.rs
+++ b/crates/facilitator/src/lib.rs
@@ -1,4 +1,4 @@
-//! x402 V2 facilitator HTTP process (r402 0.19).
+//! x402 V2 facilitator HTTP process.
 //!
 //! Composes in-process scheme facilitators and serves spec §7 routes.
 

--- a/crates/facilitator/tests/config.rs
+++ b/crates/facilitator/tests/config.rs
@@ -1,4 +1,4 @@
-//! Config schema tests for facilitator 2.0.
+//! Config schema tests.
 
 #![allow(
     unused_crate_dependencies,

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -11,7 +11,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: ghcr.io/qntx/facilitator:2.0.0
+    image: ghcr.io/qntx/facilitator:0.7.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: facilitator
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "0.7.0"
 data:
   config.toml: |
     # In-cluster bind. Signers are Secret files (source = "file"), not env.

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: facilitator
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "0.7.0"
 spec:
   # In-memory SettlementCache / PendingSettlementStore. Do not scale. No HPA.
   replicas: 1
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: facilitator
-        app.kubernetes.io/version: "2.0.0"
+        app.kubernetes.io/version: "0.7.0"
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: facilitator
-          image: ghcr.io/qntx/facilitator:2.0.0
+          image: ghcr.io/qntx/facilitator:0.7.0
           imagePullPolicy: IfNotPresent
           args: ["serve", "-c", "/etc/facilitator/config.toml"]
           env:

--- a/deploy/k8s/networkpolicy.yaml
+++ b/deploy/k8s/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: facilitator
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "0.7.0"
 spec:
   podSelector:
     matchLabels:

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -24,7 +24,7 @@ metadata:
   name: facilitator-secrets
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "0.7.0"
 type: Opaque
 stringData:
   # 0x-prefixed hex secp256k1. Replace before apply.

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: facilitator
     app.kubernetes.io/component: protocol
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "0.7.0"
 spec:
   type: ClusterIP
   selector:

--- a/deploy/k8s/servicemonitor.yaml
+++ b/deploy/k8s/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: facilitator
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "0.7.0"
 spec:
   clusterIP: None
   selector:
@@ -25,7 +25,7 @@ metadata:
   labels:
     app.kubernetes.io/name: facilitator
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "0.7.0"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Facilitator never shipped 1.0. This is 0.7.0 after 0.6.0.

- README in the r402 style
- `publish.yml` on `v*.*.*` via `publish-crates.yml@v2.0.0`
- r402 0.20.0 from crates.io (no path/git)
- CI/Docker no longer clone a sibling r402