### PR TITLE
fix: distroless nonroot image and 0.7.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,6 +35,9 @@ deploy/
 # Image uses the rust:${RUST_VERSION} compiler, not rust-toolchain.toml.
 rust-toolchain.toml
 
+# CI image scripts (run from checkout, not COPY . .)
+scripts/
+
 # Docs / misc
 *.md
 LICENSE*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,9 @@
 name: Docker
 
 # Tag v* publishes to GHCR with SBOM + provenance attestation.
-# metadata-action flavor latest=auto: v0.7.0 also moves
-# ghcr.io/qntx/facilitator:latest and :0. Operators pin :0.7.0 or a digest.
+# metadata-action flavor latest=auto: a v0.7.x tag also moves
+# ghcr.io/qntx/facilitator:latest and :0. Operators pin a 0.7.1+ tag or a digest.
+# :0.7.0 is known-bad (USER 65532 cannot traverse /etc/facilitator).
 # pull_request and workflow_dispatch are build-only (push: false, no SBOM).
 # linux/amd64 only: Dockerfile runs native cargo; dual-arch would QEMU-compile r402.
 #
@@ -63,10 +64,19 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
+          load: true
+          provenance: false
+          sbom: false
+          tags: facilitator:ci
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Assert image filesystem
+        run: scripts/image-fs-assert.sh facilitator:ci
+
+      - name: Smoke default USER
+        run: scripts/image-smoke.sh facilitator:ci
 
   publish:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
@@ -127,3 +137,15 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+      - name: Pull published digest
+        if: steps.build.outputs.digest != ''
+        run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+
+      - name: Assert published filesystem
+        if: steps.build.outputs.digest != ''
+        run: scripts/image-fs-assert.sh ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+
+      - name: Smoke published digest
+        if: steps.build.outputs.digest != ''
+        run: scripts/image-smoke.sh ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "facilitator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/facilitator"]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 # Multi-stage build. Runtime is distroless (no shell, no curl).
 # HEALTHCHECK is omitted: compose/k8s HTTP probes on /healthz and /readyz.
 #
-#   docker build -t ghcr.io/qntx/facilitator:0.7.0 .
+#   docker buildx build --load --platform linux/amd64 -t ghcr.io/qntx/facilitator:0.7.1 .
+#   OrbStack: docker-buildx build --load --platform linux/amd64 …
 
 ARG RUST_VERSION=1.95
 
@@ -16,14 +17,20 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/src/facilitator/target \
     cargo build --release --locked --bin facilitator \
-    && cp /src/facilitator/target/release/facilitator /usr/local/bin/facilitator
+    && cp /src/facilitator/target/release/facilitator /usr/local/bin/facilitator \
+    && mkdir -p /out/etc/facilitator \
+    && cp /src/facilitator/config.example.toml /out/etc/facilitator/config.toml \
+    && chmod 0755 /out/etc/facilitator \
+    && chmod 0644 /out/etc/facilitator/config.toml
 
 FROM gcr.io/distroless/cc-debian12:nonroot
 
 COPY --from=builder --chown=65532:65532 /usr/local/bin/facilitator /usr/bin/facilitator
-# Do not COPY --chmod=644 into a new directory: BuildKit applies 0644 to the
-# directory as well (no +x), so USER 65532 cannot traverse /etc/facilitator.
-COPY --chown=65532:65532 config.example.toml /etc/facilitator/config.toml
+# Do not COPY --chmod. BuildKit applies --chmod to a newly created dest
+# directory (0.7.0: /etc/facilitator became 0644, no +x; moby/moby#49851).
+# COPY the parent: /etc already exists in distroless, so facilitator/ is
+# source content (0755 in the builder) rather than a created dest dir.
+COPY --from=builder --chown=65532:65532 /out/etc /etc
 
 # In-container bind. Host example config stays 127.0.0.1; compose/k8s overlay the same vars.
 ENV FACILITATOR_HTTP_LISTEN=0.0.0.0:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=builder --chown=65532:65532 /usr/local/bin/facilitator /usr/bin/faci
 COPY --from=builder --chown=65532:65532 /out/etc /etc
 
 # In-container bind. Host example config stays 127.0.0.1; compose/k8s overlay the same vars.
+# Non-loopback listen requires [http.auth] + FACILITATOR_API_TOKEN (baked example has the table).
 ENV FACILITATOR_HTTP_LISTEN=0.0.0.0:8080
 ENV FACILITATOR_HTTP_METRICS_LISTEN=0.0.0.0:9090
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM gcr.io/distroless/cc-debian12:nonroot
 
-COPY --from=builder /usr/local/bin/facilitator /usr/bin/facilitator
-COPY --chmod=644 config.example.toml /etc/facilitator/config.toml
+COPY --from=builder --chown=65532:65532 /usr/local/bin/facilitator /usr/bin/facilitator
+# Do not COPY --chmod=644 into a new directory: BuildKit applies 0644 to the
+# directory as well (no +x), so USER 65532 cannot traverse /etc/facilitator.
+COPY --chown=65532:65532 config.example.toml /etc/facilitator/config.toml
 
 # In-container bind. Host example config stays 127.0.0.1; compose/k8s overlay the same vars.
 ENV FACILITATOR_HTTP_LISTEN=0.0.0.0:8080

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker compose up --build
 # Orb: docker-compose up --build
 ```
 
-Do not run `ghcr.io/qntx/facilitator:0.7.0` (USER 65532 cannot traverse `/etc/facilitator`). Build from this Dockerfile until `0.7.1` is published. Then pin `:0.7.1` or a digest — not `:latest` / `:0` / `:0.7`.
+Image: `ghcr.io/qntx/facilitator:0.7.1`. Pin that tag or a digest — not `:latest` / `:0` / `:0.7`. Do not run `:0.7.0` (USER 65532 cannot traverse `/etc/facilitator`). Until the `v0.7.1` GHCR tag exists, `docker compose up --build`.
 
 ## API
 
@@ -103,7 +103,7 @@ Runtime is [`gcr.io/distroless/cc-debian12:nonroot`](https://github.com/GoogleCo
 - Protocol `:8080` and metrics `:9090` are separate. Do not publish them on a public interface. [`deploy/compose.yaml`](deploy/compose.yaml) binds `127.0.0.1`. Put Caddy (or equivalent) in front. Enable `[http.auth]` bearer if the protocol port is reachable beyond localhost.
 - One replica. Settlement cache is in-memory. Do not `--scale`. k8s `strategy: Recreate`.
 - Secrets: `FACILITATOR_EVM_KEY` or a file source. Never TOML literals (startup error).
-- `ghcr.io/qntx/facilitator:0.7.0` is known-bad. Build from the Dockerfile until `0.7.1`.
+- Pin `ghcr.io/qntx/facilitator:0.7.1` or a digest. `:0.7.0` is known-bad.
 
 Compose: [`compose.yaml`](compose.yaml) (`docker compose` / Orb `docker-compose`), SVM overlay [`compose.svm.yaml`](compose.svm.yaml), TLS profile [`deploy/compose.yaml`](deploy/compose.yaml).
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Requires **Rust 1.95**.
 
 ```bash
 export FACILITATOR_EVM_KEY=0x...
+export FACILITATOR_API_TOKEN=...
 docker compose up --build
 # Orb: docker-compose up --build
 ```
 
-Image: `ghcr.io/qntx/facilitator:0.7.1`. Pin that tag or a digest — not `:latest` / `:0` / `:0.7`. Do not run `:0.7.0` (USER 65532 cannot traverse `/etc/facilitator`). Until the `v0.7.1` GHCR tag exists, `docker compose up --build`.
+Image: `ghcr.io/qntx/facilitator:0.7.1`. Pin that tag or a digest — not `:latest` / `:0` / `:0.7`. Do not run `:0.7.0` (USER 65532 cannot traverse `/etc/facilitator`).
 
 ## API
 
@@ -55,7 +56,7 @@ Image: `ghcr.io/qntx/facilitator:0.7.1`. Pin that tag or a digest — not `:late
 | `GET` | `/readyz` | Ready when at least one kind is registered |
 | `GET` | `/metrics` | Prometheus text; **metrics listen only** |
 
-No `GET /`. Optional `[http.auth]` bearer applies to `/verify`, `/settle`, `/supported`. Ops routes are unauthenticated.
+No `GET /`. `[http.auth]` bearer applies to `/verify`, `/settle`, `/supported`. Required when `http.listen` is not loopback (Docker/k8s `0.0.0.0` overlay included). Metrics listen may be `0.0.0.0` without bearer. Ops routes stay unauthenticated.
 
 ```text
 facilitator init | validate | serve
@@ -69,6 +70,9 @@ facilitator init | validate | serve
 [`config.example.toml`](config.example.toml) (EVM) and [`config.example.full.toml`](config.example.full.toml) (EVM + SVM). Named `[signer.*]` plus per-network references. Literal private keys are a startup error.
 
 ```toml
+[http.auth]
+bearer_env = "FACILITATOR_API_TOKEN"
+
 [signer.evm_hot]
 source = "env"
 env = "FACILITATOR_EVM_KEY"
@@ -79,7 +83,7 @@ signers = ["evm_hot"]
 schemes = ["exact", "upto"]
 ```
 
-Env overlay: `FACILITATOR_HTTP_LISTEN`, `FACILITATOR_HTTP_METRICS_LISTEN`, `FACILITATOR_LOG_LEVEL`, `RUST_LOG`, `FACILITATOR_CONFIG`.
+Env overlay: `FACILITATOR_HTTP_LISTEN`, `FACILITATOR_HTTP_METRICS_LISTEN`, `FACILITATOR_LOG_LEVEL`, `RUST_LOG`, `FACILITATOR_CONFIG`. Overlay re-validates: non-loopback listen without `[http.auth]` is a startup error.
 
 ## Features
 
@@ -100,9 +104,9 @@ Runtime is [`gcr.io/distroless/cc-debian12:nonroot`](https://github.com/GoogleCo
 - Image is **linux/amd64** only. Apple Silicon / Orb: `platform: linux/amd64` is set in compose (QEMU). Build with `docker buildx` (Orb: `docker-buildx`), not legacy `docker build`. Probe with **curl**, not Python urllib, under QEMU.
 - Never `--user 0`. Image USER is 65532.
 - Compose file-mount of `config.toml` requires the host file readable by uid 65532 (`config.example.toml` is 0644). Host `0600` is `EACCES` inside the container.
-- Protocol `:8080` and metrics `:9090` are separate. Do not publish them on a public interface. [`deploy/compose.yaml`](deploy/compose.yaml) binds `127.0.0.1`. Put Caddy (or equivalent) in front. Enable `[http.auth]` bearer if the protocol port is reachable beyond localhost.
+- Protocol `:8080` and metrics `:9090` are separate. Do not publish them on a public interface. [`deploy/compose.yaml`](deploy/compose.yaml) binds host `127.0.0.1`. Put Caddy (or equivalent) in front. In-container listen is `0.0.0.0`, so `[http.auth]` and `FACILITATOR_API_TOKEN` are required.
 - One replica. Settlement cache is in-memory. Do not `--scale`. k8s `strategy: Recreate`.
-- Secrets: `FACILITATOR_EVM_KEY` or a file source. Never TOML literals (startup error).
+- Secrets: `FACILITATOR_EVM_KEY` or a file source, plus `FACILITATOR_API_TOKEN`. Never TOML literals (startup error).
 - Pin `ghcr.io/qntx/facilitator:0.7.1` or a digest. `:0.7.0` is known-bad.
 
 Compose: [`compose.yaml`](compose.yaml) (`docker compose` / Orb `docker-compose`), SVM overlay [`compose.svm.yaml`](compose.svm.yaml), TLS profile [`deploy/compose.yaml`](deploy/compose.yaml).

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Requires **Rust 1.95**.
 ```bash
 export FACILITATOR_EVM_KEY=0x...
 docker compose up --build
+# Orb: docker-compose up --build
 ```
 
-Image: `ghcr.io/qntx/facilitator:0.7.0`. Pin that tag or a digest.
+Do not run `ghcr.io/qntx/facilitator:0.7.0` (USER 65532 cannot traverse `/etc/facilitator`). Build from this Dockerfile until `0.7.1` is published. Then pin `:0.7.1` or a digest — not `:latest` / `:0` / `:0.7`.
 
 ## API
 
@@ -94,11 +95,26 @@ Schemes are config lists, not Cargo features.
 
 ## Deploy
 
-Runtime is [`gcr.io/distroless/cc-debian12:nonroot`](https://github.com/GoogleContainerTools/distroless). Probe `/healthz` and `/readyz`. Drain is `settle_timeout + 5s` (default 35s).
+Runtime is [`gcr.io/distroless/cc-debian12:nonroot`](https://github.com/GoogleContainerTools/distroless) (USER **65532**). Probe `GET /healthz` and `GET /readyz`. Distroless has no `HEALTHCHECK`. Drain is `settle_timeout + 5s` (default 35s).
 
-- Compose: [`compose.yaml`](compose.yaml), SVM overlay [`compose.svm.yaml`](compose.svm.yaml), TLS profile [`deploy/compose.yaml`](deploy/compose.yaml)
-- systemd: [`deploy/systemd/facilitator.service`](deploy/systemd/facilitator.service)
-- Kubernetes: [`deploy/k8s`](deploy/k8s) — `replicas: 1`, `strategy: Recreate`
+- Image is **linux/amd64** only. Apple Silicon / Orb: `platform: linux/amd64` is set in compose (QEMU). Build with `docker buildx` (Orb: `docker-buildx`), not legacy `docker build`. Probe with **curl**, not Python urllib, under QEMU.
+- Never `--user 0`. Image USER is 65532.
+- Compose file-mount of `config.toml` requires the host file readable by uid 65532 (`config.example.toml` is 0644). Host `0600` is `EACCES` inside the container.
+- Protocol `:8080` and metrics `:9090` are separate. Do not publish them on a public interface. [`deploy/compose.yaml`](deploy/compose.yaml) binds `127.0.0.1`. Put Caddy (or equivalent) in front. Enable `[http.auth]` bearer if the protocol port is reachable beyond localhost.
+- One replica. Settlement cache is in-memory. Do not `--scale`. k8s `strategy: Recreate`.
+- Secrets: `FACILITATOR_EVM_KEY` or a file source. Never TOML literals (startup error).
+- `ghcr.io/qntx/facilitator:0.7.0` is known-bad. Build from the Dockerfile until `0.7.1`.
+
+Compose: [`compose.yaml`](compose.yaml) (`docker compose` / Orb `docker-compose`), SVM overlay [`compose.svm.yaml`](compose.svm.yaml), TLS profile [`deploy/compose.yaml`](deploy/compose.yaml).
+
+systemd: [`deploy/systemd/facilitator.service`](deploy/systemd/facilitator.service) is a **host** unit (`User=facilitator`), not distroless uid 65532.
+
+```bash
+install -d -m 0755 /etc/facilitator
+install -m 0644 /path/to/config.toml /etc/facilitator/config.toml
+```
+
+Kubernetes: [`deploy/k8s`](deploy/k8s) — `replicas: 1`, `strategy: Recreate`, `runAsUser: 65532`, ConfigMap **directory** mount at `/etc/facilitator` (not a `subPath` file mount).
 
 ## Acknowledgments
 

--- a/compose.svm.yaml
+++ b/compose.svm.yaml
@@ -1,5 +1,6 @@
-# SVM overlay on compose.yaml.
+# SVM overlay on compose.yaml. Inherits platform: linux/amd64.
 #   FACILITATOR_CONFIG=./config.example.full.toml docker compose -f compose.yaml -f compose.svm.yaml up --build
+# Default example config is EVM-only; full.toml is required for SVM tables.
 #
 # compose.yaml interpolates FACILITATOR_CONFIG for the config bind.
 # This file only adds the fee-payer key at /run/secrets/solana.key.

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,7 @@
 # Distroless image has no curl; no HEALTHCHECK. Probe HTTP /healthz /readyz.
 # File-mount host config must be readable by uid 65532 (example is 0644).
 # Do not set user:. Image USER is 65532. Do not --scale.
+# FACILITATOR_API_TOKEN is required: in-container listen is 0.0.0.0.
 
 services:
   facilitator:
@@ -23,6 +24,7 @@ services:
       FACILITATOR_HTTP_LISTEN: "0.0.0.0:8080"
       FACILITATOR_HTTP_METRICS_LISTEN: "0.0.0.0:9090"
       FACILITATOR_EVM_KEY: ${FACILITATOR_EVM_KEY}
+      FACILITATOR_API_TOKEN: ${FACILITATOR_API_TOKEN}
     volumes:
       - ${FACILITATOR_CONFIG:-./config.example.toml}:/etc/facilitator/config.toml:ro
     stop_grace_period: 35s

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,8 +2,11 @@
 #
 # Default config: config.example.toml (EVM exact+upto).
 # SVM overlay: docker compose -f compose.yaml -f compose.svm.yaml up --build
+# (Orb: docker-compose). GHCR is linux/amd64; Apple Silicon uses QEMU.
 #
 # Distroless image has no curl; no HEALTHCHECK. Probe HTTP /healthz /readyz.
+# File-mount host config must be readable by uid 65532 (example is 0644).
+# Do not set user:. Image USER is 65532. Do not --scale.
 
 services:
   facilitator:
@@ -11,6 +14,7 @@ services:
       context: .
       dockerfile: Dockerfile
     image: ghcr.io/qntx/facilitator:0.7.0
+    platform: linux/amd64
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/qntx/facilitator:0.7.0
+    image: ghcr.io/qntx/facilitator:0.7.1
     platform: linux/amd64
     restart: unless-stopped
     ports:

--- a/config.example.full.toml
+++ b/config.example.full.toml
@@ -2,6 +2,7 @@
 # constructs both). `facilitator init` writes config.example.toml (EVM only).
 #
 # Secrets: env or file. Literals for private keys are a startup error.
+# Non-loopback listen requires [http.auth]. Set FACILITATOR_API_TOKEN.
 
 [http]
 listen = "127.0.0.1:8080"
@@ -9,6 +10,9 @@ verify_timeout = "30s"
 settle_timeout = "30s"
 body_limit_bytes = 262144
 metrics_listen = "127.0.0.1:9090"
+
+[http.auth]
+bearer_env = "FACILITATOR_API_TOKEN"
 
 [log]
 level = "info"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,6 +1,7 @@
 # config.example.toml — x402 facilitator 0.7.1 (r402 0.20)
 # Secrets: env or file. Literals for private keys are a startup error.
-# Public protocol: uncomment [http.auth] and set FACILITATOR_API_TOKEN.
+# Non-loopback listen (Docker FACILITATOR_HTTP_LISTEN=0.0.0.0:8080 included)
+# requires [http.auth]. Loopback may delete the table. Set FACILITATOR_API_TOKEN.
 
 [http]
 listen = "127.0.0.1:8080"
@@ -10,8 +11,8 @@ body_limit_bytes = 262144
 metrics_listen = "127.0.0.1:9090"   # Docker/k8s: 0.0.0.0:9090 or FACILITATOR_HTTP_METRICS_LISTEN
 # cors_origins = []   # empty / omitted = no CORS layer
 
-# [http.auth]
-# bearer_env = "FACILITATOR_API_TOKEN"
+[http.auth]
+bearer_env = "FACILITATOR_API_TOKEN"
 
 [log]
 level = "info"           # RUST_LOG wins

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,5 +1,6 @@
-# config.example.toml — x402 facilitator 0.7 (r402 0.20)
+# config.example.toml — x402 facilitator 0.7.1 (r402 0.20)
 # Secrets: env or file. Literals for private keys are a startup error.
+# Public protocol: uncomment [http.auth] and set FACILITATOR_API_TOKEN.
 
 [http]
 listen = "127.0.0.1:8080"
@@ -42,6 +43,7 @@ eip1559 = true
 flashblocks = false
 receipt_timeout_secs = 20
 
+# Base mainnet. Remove this table unless the hot wallet is funded and intended.
 [network."eip155:8453"]
 rpc = ["https://mainnet.base.org"]
 signers = ["evm_hot"]

--- a/crates/facilitator/config.example.toml
+++ b/crates/facilitator/config.example.toml
@@ -1,6 +1,7 @@
 # config.example.toml — x402 facilitator 0.7.1 (r402 0.20)
 # Secrets: env or file. Literals for private keys are a startup error.
-# Public protocol: uncomment [http.auth] and set FACILITATOR_API_TOKEN.
+# Non-loopback listen (Docker FACILITATOR_HTTP_LISTEN=0.0.0.0:8080 included)
+# requires [http.auth]. Loopback may delete the table. Set FACILITATOR_API_TOKEN.
 
 [http]
 listen = "127.0.0.1:8080"
@@ -10,8 +11,8 @@ body_limit_bytes = 262144
 metrics_listen = "127.0.0.1:9090"   # Docker/k8s: 0.0.0.0:9090 or FACILITATOR_HTTP_METRICS_LISTEN
 # cors_origins = []   # empty / omitted = no CORS layer
 
-# [http.auth]
-# bearer_env = "FACILITATOR_API_TOKEN"
+[http.auth]
+bearer_env = "FACILITATOR_API_TOKEN"
 
 [log]
 level = "info"           # RUST_LOG wins

--- a/crates/facilitator/config.example.toml
+++ b/crates/facilitator/config.example.toml
@@ -1,5 +1,6 @@
-# config.example.toml — x402 facilitator 0.7 (r402 0.20)
+# config.example.toml — x402 facilitator 0.7.1 (r402 0.20)
 # Secrets: env or file. Literals for private keys are a startup error.
+# Public protocol: uncomment [http.auth] and set FACILITATOR_API_TOKEN.
 
 [http]
 listen = "127.0.0.1:8080"
@@ -42,6 +43,7 @@ eip1559 = true
 flashblocks = false
 receipt_timeout_secs = 20
 
+# Base mainnet. Remove this table unless the hot wallet is funded and intended.
 [network."eip155:8453"]
 rpc = ["https://mainnet.base.org"]
 signers = ["evm_hot"]

--- a/crates/facilitator/src/config/mod.rs
+++ b/crates/facilitator/src/config/mod.rs
@@ -201,16 +201,23 @@ fn parse_networks(raw: toml::Table) -> Result<Vec<Network>, Error> {
 impl Config {
     /// Overlay `FACILITATOR_HTTP_*`, `FACILITATOR_LOG_LEVEL`, and `RUST_LOG`.
     ///
+    /// Re-validates afterwards so `FACILITATOR_HTTP_LISTEN=0.0.0.0:8080` cannot
+    /// skip the non-loopback `[http.auth]` requirement.
+    ///
     /// # Errors
     ///
-    /// Invalid socket addresses in overlay env vars.
+    /// Invalid socket addresses in overlay env vars, or post-overlay validation.
     pub fn overlay_env(&mut self) -> Result<(), Error> {
-        if let Ok(raw) = std::env::var("FACILITATOR_HTTP_LISTEN") {
+        self.overlay_from(&|key| std::env::var(key).ok())
+    }
+
+    fn overlay_from(&mut self, lookup: &impl Fn(&str) -> Option<String>) -> Result<(), Error> {
+        if let Some(raw) = lookup("FACILITATOR_HTTP_LISTEN") {
             self.http.listen = raw.parse().map_err(|err| {
                 Error::config_with(format!("invalid FACILITATOR_HTTP_LISTEN '{raw}'"), err)
             })?;
         }
-        if let Ok(raw) = std::env::var("FACILITATOR_HTTP_METRICS_LISTEN") {
+        if let Some(raw) = lookup("FACILITATOR_HTTP_METRICS_LISTEN") {
             self.http.metrics_listen = Some(raw.parse().map_err(|err| {
                 Error::config_with(
                     format!("invalid FACILITATOR_HTTP_METRICS_LISTEN '{raw}'"),
@@ -218,13 +225,13 @@ impl Config {
                 )
             })?);
         }
-        if let Ok(level) = std::env::var("FACILITATOR_LOG_LEVEL") {
+        if let Some(level) = lookup("FACILITATOR_LOG_LEVEL") {
             self.log.level = level;
         }
-        if let Ok(level) = std::env::var("RUST_LOG") {
+        if let Some(level) = lookup("RUST_LOG") {
             self.log.level = level;
         }
-        Ok(())
+        self.validate()
     }
 
     /// Resolve every signer and `rpc_env`. Does not keep secret material.
@@ -291,6 +298,12 @@ impl Config {
     }
 
     fn validate_http_auth(&self) -> Result<(), Error> {
+        if !self.http.listen.ip().is_loopback() && self.http.auth.is_none() {
+            return Err(Error::config(format!(
+                "non-loopback [http] listen {} requires [http.auth]; bind 127.0.0.1/::1 to omit bearer",
+                self.http.listen
+            )));
+        }
         let Some(auth) = &self.http.auth else {
             return Ok(());
         };
@@ -402,4 +415,60 @@ fn resolve_network_env(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod overlay_tests {
+    use super::*;
+
+    const LOOPBACK: &str = r#"
+[http]
+listen = "127.0.0.1:8080"
+settle_timeout = "30s"
+
+[signer.evm_hot]
+source = "env"
+env = "FACILITATOR_EVM_KEY"
+
+[network."eip155:84532"]
+rpc = ["https://sepolia.base.org"]
+signers = ["evm_hot"]
+schemes = ["exact"]
+receipt_timeout_secs = 20
+"#;
+
+    #[test]
+    fn overlay_unspecified_listen_without_auth_fails() {
+        let mut cfg = parse_config_toml(LOOPBACK).expect("parse");
+        let err = cfg
+            .overlay_from(&|key| {
+                (key == "FACILITATOR_HTTP_LISTEN").then(|| "0.0.0.0:8080".to_owned())
+            })
+            .expect_err("must require auth");
+        let msg = err.to_string();
+        assert!(msg.contains("non-loopback"), "got {msg}");
+        assert!(msg.contains("[http.auth]"), "got {msg}");
+    }
+
+    #[test]
+    fn overlay_unspecified_listen_with_auth_ok() {
+        let raw = format!("{LOOPBACK}\n[http.auth]\nbearer_env = \"FACILITATOR_API_TOKEN\"\n");
+        let mut cfg = parse_config_toml(&raw).expect("parse");
+        cfg.overlay_from(&|key| {
+            (key == "FACILITATOR_HTTP_LISTEN").then(|| "0.0.0.0:8080".to_owned())
+        })
+        .expect("auth present");
+        assert_eq!(
+            cfg.http.listen,
+            "0.0.0.0:8080".parse().expect("listen"),
+            "overlay applied"
+        );
+    }
+
+    #[test]
+    fn overlay_absent_keeps_loopback_without_auth() {
+        let mut cfg = parse_config_toml(LOOPBACK).expect("parse");
+        cfg.overlay_from(&|_| None).expect("no overlay");
+        assert!(cfg.http.listen.ip().is_loopback(), "listen stays loopback");
+    }
 }

--- a/crates/facilitator/tests/config.rs
+++ b/crates/facilitator/tests/config.rs
@@ -1110,8 +1110,12 @@ schemes = ["exact"]
 #[test]
 fn resolve_secrets_reads_env_lookup() {
     let cfg = parse_config_toml(&repo_file("config.example.toml")).expect("parse");
-    cfg.resolve_secrets(&|key| (key == "FACILITATOR_EVM_KEY").then(|| "not-logged".to_owned()))
-        .expect("lookup supplies the env signer");
+    cfg.resolve_secrets(&|key| match key {
+        "FACILITATOR_EVM_KEY" => Some("not-logged".to_owned()),
+        "FACILITATOR_API_TOKEN" => Some("not-logged-token".to_owned()),
+        _ => None,
+    })
+    .expect("lookup supplies the env signer and bearer");
 }
 
 #[test]
@@ -1169,4 +1173,57 @@ fn http_auth_resolves_token() {
         .expect("resolves")
         .expect("present");
     assert_eq!(token, "shared-token", "trimmed");
+}
+
+#[test]
+fn packaged_example_matches_repo_example() {
+    let repo = repo_file("config.example.toml");
+    let packaged = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.example.toml"),
+    )
+    .expect("crate example");
+    assert_eq!(
+        packaged, repo,
+        "crates/facilitator/config.example.toml must match repo root"
+    );
+}
+
+#[test]
+fn example_toml_enables_http_auth() {
+    let raw = repo_file("config.example.toml");
+    assert!(
+        raw.contains("\n[http.auth]\n"),
+        "example must ship an uncommented [http.auth] table"
+    );
+}
+
+#[test]
+fn non_loopback_listen_without_auth_fails() {
+    let raw = evm_doc("").replace(r#"listen = "127.0.0.1:8080""#, r#"listen = "0.0.0.0:8080""#);
+    let err = parse_config_toml(&raw).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("non-loopback"), "got {msg}");
+    assert!(msg.contains("[http.auth]"), "got {msg}");
+}
+
+#[test]
+fn ipv6_unspecified_listen_without_auth_fails() {
+    let raw = evm_doc("").replace(r#"listen = "127.0.0.1:8080""#, r#"listen = "[::]:8080""#);
+    let err = parse_config_toml(&raw).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("non-loopback"), "got {msg}");
+    assert!(msg.contains("[http.auth]"), "got {msg}");
+}
+
+#[test]
+fn ipv6_loopback_listen_without_auth_ok() {
+    let raw = evm_doc("").replace(r#"listen = "127.0.0.1:8080""#, r#"listen = "[::1]:8080""#);
+    parse_config_toml(&raw).expect("::1 may omit [http.auth]");
+}
+
+#[test]
+fn non_loopback_listen_with_auth_ok() {
+    let raw = evm_doc("[http.auth]\nbearer_env = \"FACILITATOR_API_TOKEN\"\n")
+        .replace(r#"listen = "127.0.0.1:8080""#, r#"listen = "0.0.0.0:8080""#);
+    parse_config_toml(&raw).expect("auth covers 0.0.0.0");
 }

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,6 +1,8 @@
 # Replace the hostname. Caddy provisions Let's Encrypt on :80/:443.
 # No reverse_proxy transport timeout: Axum settle_timeout (default 30s) is the process cap.
 # Do not proxy /metrics (metrics listen is 9090, not the protocol port).
+# /verify /settle /supported require Authorization: Bearer (facilitator [http.auth]).
+# Caddy forwards that header. /healthz /readyz stay unauthenticated.
 
 facilitator.example.com {
 	encode gzip

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -6,6 +6,7 @@
 #
 # Distroless image has no curl; no HEALTHCHECK. Probe HTTP /healthz /readyz.
 # GHCR is linux/amd64. Host config file-mount must be readable by uid 65532.
+# FACILITATOR_API_TOKEN is required: in-container listen is 0.0.0.0.
 
 services:
   facilitator:
@@ -22,6 +23,7 @@ services:
       FACILITATOR_HTTP_LISTEN: "0.0.0.0:8080"
       FACILITATOR_HTTP_METRICS_LISTEN: "0.0.0.0:9090"
       FACILITATOR_EVM_KEY: ${FACILITATOR_EVM_KEY}
+      FACILITATOR_API_TOKEN: ${FACILITATOR_API_TOKEN}
     volumes:
       - ${FACILITATOR_CONFIG:-../config.example.toml}:/etc/facilitator/config.toml:ro
     stop_grace_period: 35s

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -12,7 +12,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: ghcr.io/qntx/facilitator:0.7.0
+    image: ghcr.io/qntx/facilitator:0.7.1
     platform: linux/amd64
     restart: unless-stopped
     ports:

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -5,6 +5,7 @@
 #   docker compose -f deploy/compose.yaml --profile tls up
 #
 # Distroless image has no curl; no HEALTHCHECK. Probe HTTP /healthz /readyz.
+# GHCR is linux/amd64. Host config file-mount must be readable by uid 65532.
 
 services:
   facilitator:
@@ -12,6 +13,7 @@ services:
       context: ..
       dockerfile: Dockerfile
     image: ghcr.io/qntx/facilitator:0.7.0
+    platform: linux/amd64
     restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: facilitator
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
 data:
   config.toml: |
     # In-cluster bind. Signers are Secret files (source = "file"), not env.

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -17,6 +17,9 @@ data:
     body_limit_bytes = 262144
     metrics_listen = "0.0.0.0:9090"
 
+    [http.auth]
+    bearer_env = "FACILITATOR_API_TOKEN"
+
     [log]
     level = "info"
     format = "json"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -39,6 +39,11 @@ spec:
               value: "0.0.0.0:8080"
             - name: FACILITATOR_HTTP_METRICS_LISTEN
               value: "0.0.0.0:9090"
+            - name: FACILITATOR_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: facilitator-secrets
+                  key: api-token
           ports:
             - name: protocol
               containerPort: 8080

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -75,6 +75,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           volumeMounts:
+            # Directory mount (not subPath). Replaces /etc/facilitator.
             - name: config
               mountPath: /etc/facilitator
               readOnly: true

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: facilitator
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
 spec:
   # In-memory SettlementCache / PendingSettlementStore. Do not scale. No HPA.
   replicas: 1
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: facilitator
-        app.kubernetes.io/version: "0.7.0"
+        app.kubernetes.io/version: "0.7.1"
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: facilitator
-          image: ghcr.io/qntx/facilitator:0.7.0
+          image: ghcr.io/qntx/facilitator:0.7.1
           imagePullPolicy: IfNotPresent
           args: ["serve", "-c", "/etc/facilitator/config.toml"]
           env:

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,5 +1,5 @@
 # One replica (in-memory SettlementCache). No HPA.
-# Replace facilitator-secrets.evm.key before the pod will serve.
+# Replace facilitator-secrets.evm.key and api-token before the pod will serve.
 # SVM is opt-in: solana.key in the Secret is not mounted until you add the
 # volume item in deployment.yaml and SVM tables in the ConfigMap.
 #

--- a/deploy/k8s/networkpolicy.yaml
+++ b/deploy/k8s/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: facilitator
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
 spec:
   podSelector:
     matchLabels:

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -24,7 +24,7 @@ metadata:
   name: facilitator-secrets
   labels:
     app.kubernetes.io/name: facilitator
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
 type: Opaque
 stringData:
   # 0x-prefixed hex secp256k1. Replace before apply.

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -29,5 +29,7 @@ type: Opaque
 stringData:
   # 0x-prefixed hex secp256k1. Replace before apply.
   evm.key: "REPLACE_WITH_0x_PREFIXED_HEX_SECP256K1"
+  # Shared bearer for /verify /settle /supported. Required: listen is 0.0.0.0.
+  api-token: "REPLACE_WITH_FACILITATOR_API_TOKEN"
   # Optional. Not mounted by the default Deployment.
   solana.key: "REPLACE_WITH_BASE58_SOLANA_FEE_PAYER"

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: facilitator
     app.kubernetes.io/component: protocol
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
 spec:
   type: ClusterIP
   selector:

--- a/deploy/k8s/servicemonitor.yaml
+++ b/deploy/k8s/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: facilitator
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
 spec:
   clusterIP: None
   selector:
@@ -25,7 +25,7 @@ metadata:
   labels:
     app.kubernetes.io/name: facilitator
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
 spec:
   selector:
     matchLabels:

--- a/deploy/systemd/facilitator.service
+++ b/deploy/systemd/facilitator.service
@@ -9,6 +9,7 @@ Type=simple
 User=facilitator
 Group=facilitator
 Restart=on-failure
+# env: FACILITATOR_EVM_KEY and FACILITATOR_API_TOKEN ([http.auth] / non-loopback listen)
 EnvironmentFile=-/etc/facilitator/env
 ExecStart=/usr/bin/facilitator serve -c /etc/facilitator/config.toml
 TimeoutStopSec=35

--- a/scripts/image-fs-assert.py
+++ b/scripts/image-fs-assert.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Assert distroless facilitator image filesystem mode from `docker export` stdin.
+
+Export member names have no leading slash. TarInfo.mode includes type bits;
+compare with stat.S_IMODE.
+"""
+
+from __future__ import annotations
+
+import stat
+import sys
+import tarfile
+
+UID = 65532
+DIR_MODE = 0o755
+
+
+def fail(msg: str) -> None:
+    print(f"image-fs-assert: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    wanted = {
+        "etc/facilitator": "dir",
+        "etc/facilitator/config.toml": "file",
+        "usr/bin/facilitator": "bin",
+    }
+    found: dict[str, tarfile.TarInfo] = {}
+    with tarfile.open(fileobj=sys.stdin.buffer, mode="r|") as tar:
+        for ti in tar:
+            name = ti.name.lstrip("./")
+            if name.endswith("/") and name[:-1] in wanted:
+                name = name[:-1]
+            if name in wanted:
+                found[name] = ti
+
+    for path, kind in wanted.items():
+        ti = found.get(path)
+        if ti is None:
+            fail(f"missing {path}")
+        mode = stat.S_IMODE(ti.mode)
+        if ti.uid != UID or ti.gid != UID:
+            fail(f"{path} uid:gid {ti.uid}:{ti.gid}, want {UID}:{UID}")
+        if kind == "dir":
+            if not ti.isdir():
+                fail(f"{path} is not a directory")
+            if mode != DIR_MODE:
+                fail(f"{path} mode {oct(mode)}, want {oct(DIR_MODE)}")
+        elif kind == "file":
+            if not ti.isreg():
+                fail(f"{path} is not a regular file")
+            if mode & 0o400 == 0:
+                fail(f"{path} not owner-readable ({oct(mode)})")
+        else:
+            if not ti.isreg():
+                fail(f"{path} is not a regular file")
+            if mode & 0o100 == 0:
+                fail(f"{path} not owner-executable ({oct(mode)})")
+
+    print("image-fs-assert: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/image-fs-assert.sh
+++ b/scripts/image-fs-assert.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Assert /etc/facilitator is traversable by USER 65532 without starting serve.
+set -euo pipefail
+
+IMAGE=${1:?usage: image-fs-assert.sh IMAGE}
+HERE=$(cd "$(dirname "$0")" && pwd)
+cid=""
+cleanup() {
+  if [[ -n "$cid" ]]; then
+    docker rm -f "$cid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+cid=$(docker create --platform linux/amd64 "$IMAGE")
+docker export "$cid" | python3 "$HERE/image-fs-assert.py"

--- a/scripts/image-smoke.sh
+++ b/scripts/image-smoke.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Run the image as the default USER (no --user). Probe protocol + metrics.
+set -euo pipefail
+
+IMAGE=${1:?usage: image-smoke.sh IMAGE}
+NAME=fac-smoke
+HTTP=18080
+METRICS=19090
+# Anvil account 0. Same constant as crates/facilitator/tests/compose_supported.rs.
+# Construction-only. Do not broadcast.
+export FACILITATOR_EVM_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+ANVIL_ADDR=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+cleanup
+
+user=$(docker inspect -f '{{.Config.User}}' "$IMAGE")
+case "$user" in
+  65532|65532:65532) ;;
+  *)
+    echo "image-smoke: Config.User=$user want 65532" >&2
+    exit 1
+    ;;
+esac
+
+docker run -d --name "$NAME" --platform linux/amd64 \
+  -e FACILITATOR_EVM_KEY \
+  -e FACILITATOR_HTTP_LISTEN=0.0.0.0:8080 \
+  -e FACILITATOR_HTTP_METRICS_LISTEN=0.0.0.0:9090 \
+  -p 127.0.0.1:${HTTP}:8080 -p 127.0.0.1:${METRICS}:9090 \
+  "$IMAGE" >/dev/null
+
+up=0
+for _ in $(seq 1 60); do
+  if curl -fsS -o /dev/null --max-time 2 "http://127.0.0.1:${HTTP}/healthz"; then
+    up=1
+    break
+  fi
+  st=$(docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' "$NAME")
+  if [[ "$st" == exited* ]]; then
+    echo "image-smoke: container exited: $st" >&2
+    docker logs "$NAME" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "$up" -ne 1 ]]; then
+  echo "image-smoke: /healthz timeout" >&2
+  docker logs "$NAME" >&2 || true
+  exit 1
+fi
+
+python3 - "$HTTP" "$METRICS" "$ANVIL_ADDR" << 'PY'
+import json, subprocess, sys
+
+http, metrics, anvil = sys.argv[1], sys.argv[2], sys.argv[3]
+
+
+def curl(method, url, data=None, timeout=20):
+    cmd = [
+        "curl", "-sS", "-o", "/tmp/fac-smoke-body", "-w", "%{http_code}",
+        "--max-time", str(timeout), "-X", method, url,
+    ]
+    if data is not None:
+        cmd += ["-H", "content-type: application/json", "--data", data]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    code = int(p.stdout.strip() or "0")
+    body = open("/tmp/fac-smoke-body", "rb").read()
+    if p.returncode != 0 and code == 0:
+        raise SystemExit(f"curl failed {url}: {p.stderr}")
+    return code, body
+
+
+def must(ok, msg):
+    if not ok:
+        raise SystemExit(f"image-smoke: {msg}")
+
+
+def jload(raw):
+    return json.loads(raw)
+
+
+st, raw = curl("GET", f"http://127.0.0.1:{http}/healthz")
+j = jload(raw)
+must(st == 200 and j.get("status") == "ok", f"/healthz {st} {raw!r}")
+
+st, raw = curl("GET", f"http://127.0.0.1:{http}/readyz")
+j = jload(raw)
+must(st == 200 and j.get("status") == "ok", f"/readyz {st} {raw!r}")
+
+st, raw = curl("GET", f"http://127.0.0.1:{http}/supported")
+j = jload(raw)
+must(st == 200, f"/supported {st} {raw!r}")
+kinds = j.get("kinds") or []
+pairs = {(k.get("network"), k.get("scheme")) for k in kinds}
+want = {
+    ("eip155:84532", "exact"),
+    ("eip155:84532", "upto"),
+    ("eip155:8453", "exact"),
+    ("eip155:8453", "upto"),
+}
+must(pairs == want, f"/supported kinds {pairs}")
+must(all(k.get("x402Version") == 2 for k in kinds), "/supported x402Version")
+signers = json.dumps(j.get("signers") or {}).lower()
+must(anvil.lower() in json.dumps(j).lower(), f"/supported missing {anvil}")
+must("eip155:" in signers or anvil.lower() in json.dumps(j).lower(), "/supported signers")
+
+for path in ("/", "/health", "/metrics"):
+    st, raw = curl("GET", f"http://127.0.0.1:{http}{path}")
+    must(st == 404, f"GET {path} {st}")
+
+st, raw = curl("POST", f"http://127.0.0.1:{http}/verify", data="{")
+j = jload(raw)
+must(st == 400 and j.get("error") == "invalid request body", f"unparseable {st} {raw!r}")
+
+st, raw = curl(
+    "POST",
+    f"http://127.0.0.1:{http}/verify",
+    data='{"x402Version":1,"paymentPayload":{},"paymentRequirements":{}}',
+)
+j = jload(raw)
+must(
+    st == 200 and j.get("isValid") is False and j.get("invalidReason") == "invalid_x402_version",
+    f"v1 verify {st} {raw!r}",
+)
+
+st, raw = curl(
+    "POST",
+    f"http://127.0.0.1:{http}/verify",
+    data='{"x402Version":2,"paymentPayload":{},"paymentRequirements":{"network":"eip155:84532"}}',
+)
+j = jload(raw)
+must(
+    st == 200 and j.get("isValid") is False and j.get("invalidReason") == "invalid_payload",
+    f"v2 empty {st} {raw!r}",
+)
+
+st, raw = curl(
+    "POST",
+    f"http://127.0.0.1:{http}/settle",
+    data='{"x402Version":1,"paymentPayload":{},"paymentRequirements":{}}',
+)
+j = jload(raw)
+must(
+    st == 200
+    and j.get("success") is False
+    and j.get("errorReason") == "invalid_x402_version",
+    f"v1 settle {st} {raw!r}",
+)
+
+st, raw = curl("GET", f"http://127.0.0.1:{metrics}/metrics")
+must(st == 200, f"metrics {st}")
+text = raw.decode("utf-8", "replace")
+must("r402_facilitator_verify_total" in text, f"metrics missing verify_total {text[:200]!r}")
+
+print("image-smoke: ok")
+PY

--- a/scripts/image-smoke.sh
+++ b/scripts/image-smoke.sh
@@ -32,6 +32,14 @@ docker run -d --name "$NAME" --platform linux/amd64 \
   -e FACILITATOR_HTTP_METRICS_LISTEN=0.0.0.0:9090 \
   -p 127.0.0.1:${HTTP}:8080 -p 127.0.0.1:${METRICS}:9090 \
   "$IMAGE" >/dev/null
+run_user=$(docker inspect -f '{{.Config.User}}' "$NAME")
+case "$run_user" in
+  65532|65532:65532) ;;
+  *)
+    echo "image-smoke: container User=$run_user want 65532" >&2
+    exit 1
+    ;;
+esac
 
 up=0
 for _ in $(seq 1 60); do

--- a/scripts/image-smoke.sh
+++ b/scripts/image-smoke.sh
@@ -9,6 +9,7 @@ METRICS=19090
 # Anvil account 0. Same constant as crates/facilitator/tests/compose_supported.rs.
 # Construction-only. Do not broadcast.
 export FACILITATOR_EVM_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export FACILITATOR_API_TOKEN=image-smoke-token
 ANVIL_ADDR=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
 cleanup() {
@@ -28,6 +29,7 @@ esac
 
 docker run -d --name "$NAME" --platform linux/amd64 \
   -e FACILITATOR_EVM_KEY \
+  -e FACILITATOR_API_TOKEN \
   -e FACILITATOR_HTTP_LISTEN=0.0.0.0:8080 \
   -e FACILITATOR_HTTP_METRICS_LISTEN=0.0.0.0:9090 \
   -p 127.0.0.1:${HTTP}:8080 -p 127.0.0.1:${METRICS}:9090 \
@@ -65,13 +67,17 @@ python3 - "$HTTP" "$METRICS" "$ANVIL_ADDR" << 'PY'
 import json, subprocess, sys
 
 http, metrics, anvil = sys.argv[1], sys.argv[2], sys.argv[3]
+AUTH = {"authorization": "Bearer image-smoke-token"}
 
 
-def curl(method, url, data=None, timeout=20):
+def curl(method, url, data=None, timeout=20, headers=None):
     cmd = [
         "curl", "-sS", "-o", "/tmp/fac-smoke-body", "-w", "%{http_code}",
         "--max-time", str(timeout), "-X", method, url,
     ]
+    if headers:
+        for key, value in headers.items():
+            cmd += ["-H", f"{key}: {value}"]
     if data is not None:
         cmd += ["-H", "content-type: application/json", "--data", data]
     p = subprocess.run(cmd, capture_output=True, text=True)
@@ -101,6 +107,10 @@ must(st == 200 and j.get("status") == "ok", f"/readyz {st} {raw!r}")
 
 st, raw = curl("GET", f"http://127.0.0.1:{http}/supported")
 j = jload(raw)
+must(st == 401 and j.get("error") == "unauthorized", f"/supported unauth {st} {raw!r}")
+
+st, raw = curl("GET", f"http://127.0.0.1:{http}/supported", headers=AUTH)
+j = jload(raw)
 must(st == 200, f"/supported {st} {raw!r}")
 kinds = j.get("kinds") or []
 pairs = {(k.get("network"), k.get("scheme")) for k in kinds}
@@ -120,7 +130,7 @@ for path in ("/", "/health", "/metrics"):
     st, raw = curl("GET", f"http://127.0.0.1:{http}{path}")
     must(st == 404, f"GET {path} {st}")
 
-st, raw = curl("POST", f"http://127.0.0.1:{http}/verify", data="{")
+st, raw = curl("POST", f"http://127.0.0.1:{http}/verify", data="{", headers=AUTH)
 j = jload(raw)
 must(st == 400 and j.get("error") == "invalid request body", f"unparseable {st} {raw!r}")
 
@@ -128,6 +138,7 @@ st, raw = curl(
     "POST",
     f"http://127.0.0.1:{http}/verify",
     data='{"x402Version":1,"paymentPayload":{},"paymentRequirements":{}}',
+    headers=AUTH,
 )
 j = jload(raw)
 must(
@@ -139,6 +150,7 @@ st, raw = curl(
     "POST",
     f"http://127.0.0.1:{http}/verify",
     data='{"x402Version":2,"paymentPayload":{},"paymentRequirements":{"network":"eip155:84532"}}',
+    headers=AUTH,
 )
 j = jload(raw)
 must(
@@ -150,6 +162,7 @@ st, raw = curl(
     "POST",
     f"http://127.0.0.1:{http}/settle",
     data='{"x402Version":1,"paymentPayload":{},"paymentRequirements":{}}',
+    headers=AUTH,
 )
 j = jload(raw)
 must(


### PR DESCRIPTION
## Summary

`ghcr.io/qntx/facilitator:0.7.0` is not runnable as USER 65532: `COPY --chmod=644` made `/etc/facilitator` mode 0644.

This PR:

- Runtime `COPY --chown=65532:65532 /out/etc /etc` (dir is source content of existing distroless `/etc`)
- CI `load: true` + `scripts/image-fs-assert.sh` + `scripts/image-smoke.sh` (default user, no `--user`)
- compose `platform: linux/amd64`
- crate/image/k8s pin **0.7.1**
- README: do not run `:0.7.0`
- Fail-closed: non-loopback `[http] listen` (including Docker/k8s `FACILITATOR_HTTP_LISTEN=0.0.0.0:8080`) requires `[http.auth]`. Overlay re-validates. Example, compose, and k8s ship `FACILITATOR_API_TOKEN`. Metrics listen may stay `0.0.0.0` without bearer. `/healthz` `/readyz` stay unauthenticated.

After merge, tag `v0.7.1` to publish GHCR + crates.io.

Native `cargo build --release` / `facilitator serve` was already fine; this is packaging + version + public-bind auth.

## Test

- `cargo test --package facilitator --test config` 40 tests ok
- `cargo test --package facilitator --lib overlay_` ok
- `cargo +nightly clippy --package facilitator --all-targets -- -D warnings` ok
- `facilitator --version` → 0.7.1
- Orb: fs-assert local pass; `:0.7.0` fail; smoke; compose `--no-build` after retag